### PR TITLE
feat: CustomUserDetails, CustomUserDetailsService 추가

### DIFF
--- a/src/main/java/org/example/hugmeexp/global/infra/auth/dto/request/LoginRequest.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/dto/request/LoginRequest.java
@@ -1,6 +1,5 @@
 package org.example.hugmeexp.global.infra.auth.dto.request;
 
-
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;

--- a/src/main/java/org/example/hugmeexp/global/infra/auth/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/jwt/JwtAuthenticationEntryPoint.java
@@ -1,7 +1,10 @@
 package org.example.hugmeexp.global.infra.auth.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.example.hugmeexp.global.common.exception.response.ErrorResponse;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -12,14 +15,23 @@ import java.io.IOException;
  * 인증 실패 시, JSON 형태로 401 응답을 반환하는 진입 지점
  */
 @Component
+@RequiredArgsConstructor
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint
 {
+    private final ObjectMapper objectMapper;
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException
     {
-
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json;charset=UTF-8");
-        response.getWriter().write("{\"error\": \"Unauthorized\"}");
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .code(401)
+                .message("Unauthorized")
+                .build();
+
+        String json = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(json);
     }
 }

--- a/src/main/java/org/example/hugmeexp/global/infra/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/jwt/JwtTokenProvider.java
@@ -142,7 +142,7 @@ public class JwtTokenProvider {
         }
     }
 
-    // 토큰의 만료시간을 조회하는 메섣,(액세스, 리프레시 둘다 사용 가능)
+    // 토큰의 만료시간을 조회하는 메서드,(액세스, 리프레시 둘다 사용 가능)
     public long getTokenRemainingTimeMillis(String token) {
         try {
             Date expiration = Jwts.parserBuilder()

--- a/src/main/java/org/example/hugmeexp/global/infra/auth/service/AuthService.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/service/AuthService.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /*
-    AuthService는 중재자 패턴(Mediator Pattern)을 구현한 서비스 클래스로, 인증 관련 모든 비즈니스 로직을 통합 관리한다.
+    AuthService는 중재자 패턴(Mediator Pattern)을 구현한 서비스 클래스로, 인증 관련 모든 비즈니스 로직을 통합 관리
     세부 구현은 UserService와 TokenService에 위임
 */
 @Slf4j

--- a/src/main/java/org/example/hugmeexp/global/security/CustomUserDetails.java
+++ b/src/main/java/org/example/hugmeexp/global/security/CustomUserDetails.java
@@ -1,0 +1,38 @@
+package org.example.hugmeexp.global.security;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.example.hugmeexp.global.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+}

--- a/src/main/java/org/example/hugmeexp/global/security/CustomUserDetailsService.java
+++ b/src/main/java/org/example/hugmeexp/global/security/CustomUserDetailsService.java
@@ -1,0 +1,23 @@
+package org.example.hugmeexp.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.example.hugmeexp.global.common.repository.UserRepository;
+import org.example.hugmeexp.global.entity.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다."));
+        return new CustomUserDetails(user);
+    }
+}


### PR DESCRIPTION
@AuthenticationPricipal 애노테이션을 위해서 CustomUserDetails, CustomUserDetailsService 추가하였습니다.

이로 인해서 JWT필터, security config 로직도 수정하였습니다.

@AuthenticationPricipal를 사용해본적이 없어서 이렇게하면 되는지는 잘모르겠습니다.

판단 부탁드립니다.

참고로 액세스토큰 없이 접근하는 사용자에게 전달하는 메시지도 아래와 같이 수정했습니다.

```json
{
    "code": 401,
    "message": "Unauthorized"
}

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - Spring Security와 연동되는 사용자 정보 제공 클래스(`CustomUserDetails`) 및 사용자 조회 서비스(`CustomUserDetailsService`)가 추가되었습니다.

- **버그 수정**
    - 인증 실패 및 토큰 블랙리스트 상황에서 구조화된 JSON 에러 응답이 반환되도록 개선되었습니다.

- **리팩터링**
    - JWT 인증 필터가 사용자 권한을 직접 파싱하는 대신, 사용자 정보를 서비스에서 조회하도록 변경되었습니다.
    - 시큐리티 설정에서 일부 경로 권한 규칙이 조정되고, 불필요한 인증 매니저 빈이 제거되었습니다.

- **문서**
    - 일부 클래스 및 메서드 주석이 수정되었습니다.

- **스타일**
    - 코드 내 불필요한 빈 줄이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->