### PR TITLE
feat: H2 콘솔 접근을 위한 설정

### DIFF
--- a/src/main/java/org/example/hugmeexp/global/security/config/SecurityConfig.java
+++ b/src/main/java/org/example/hugmeexp/global/security/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults()) // CORS 활성화 (WebMvcConfigurer의 설정 사용)
                 .csrf(AbstractHttpConfigurer::disable) // JWT 기반 인증은 브라우저 세션을 사용하지 않으므로 CSRF 불필요
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // STATELESS
-                .headers(headers -> headers.frameOptions().disable()) // H2 콘솔 사용을 위해 프레임 옵션 비활성화
+                .headers(headers -> headers.frameOptions().sameOrigin())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/login", "/api/register", "/api/refresh", "/api/logout",


### PR DESCRIPTION

임시로 /h2-console 접근을 위한 프레임 옵션 비활성화 및 requestMatchers 설정을 넣었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
  - H2 콘솔에 인증 없이 접근할 수 있도록 허용되었습니다.
  - H2 콘솔이 프레임 내에서 정상적으로 표시될 수 있도록 보안 설정이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->