### PR TITLE
출석체크 구현, postman, 테스트 완료

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/attendance/controller/AttendanceController.java
+++ b/src/main/java/org/example/hugmeexp/domain/attendance/controller/AttendanceController.java
@@ -1,0 +1,26 @@
+package org.example.hugmeexp.domain.attendance.controller;
+
+import org.example.hugmeexp.domain.attendance.dto.AttendanceCheckRequest;
+import org.example.hugmeexp.domain.attendance.dto.AttendanceCheckResponse;
+import org.example.hugmeexp.domain.attendance.dto.AttendanceStatusResponse;
+import org.example.hugmeexp.domain.attendance.service.AttendanceService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/attendance")
+public class AttendanceController {
+
+    @Autowired
+    private AttendanceService attendanceService;
+
+    @GetMapping
+    public AttendanceStatusResponse getAttendanceStatus(@RequestParam Long userId) {
+        return attendanceService.getAttendanceStatus(userId);
+    }
+
+    @PostMapping("/check")
+    public AttendanceCheckResponse checkAttendance(@RequestParam Long userId, @RequestBody AttendanceCheckRequest request) {
+        return attendanceService.checkAttendance(userId, request);
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/attendance/dto/AttendanceCheckRequest.java
+++ b/src/main/java/org/example/hugmeexp/domain/attendance/dto/AttendanceCheckRequest.java
@@ -1,0 +1,22 @@
+package org.example.hugmeexp.domain.attendance.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AttendanceCheckRequest {
+
+    private final Long userId;
+
+    public AttendanceCheckRequest(Long userId) {
+        this.userId = userId;
+    }
+
+    public static AttendanceCheckRequest ofCheck(Long userId) {
+        return AttendanceCheckRequest.builder()
+                .userId(userId)
+                .build();
+    }
+
+}

--- a/src/main/java/org/example/hugmeexp/domain/attendance/dto/AttendanceCheckResponse.java
+++ b/src/main/java/org/example/hugmeexp/domain/attendance/dto/AttendanceCheckResponse.java
@@ -1,0 +1,22 @@
+package org.example.hugmeexp.domain.attendance.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AttendanceCheckResponse {
+    private final boolean attend;
+    private final int exp;
+    private final int point;
+
+    public static AttendanceCheckResponse of(boolean attend, int exp, int point) {
+        return new AttendanceCheckResponse(attend, exp, point);
+    }
+
+    private AttendanceCheckResponse(boolean attend, int exp, int point) {
+        this.attend = attend;
+        this.exp = exp;
+        this.point = point;
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/attendance/dto/AttendanceStatusResponse.java
+++ b/src/main/java/org/example/hugmeexp/domain/attendance/dto/AttendanceStatusResponse.java
@@ -1,0 +1,25 @@
+package org.example.hugmeexp.domain.attendance.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class AttendanceStatusResponse {
+
+    // 일요일~토요일 출석 여부 (true: 출석, false: 결석)
+    private final boolean[] attendanceStatus;
+
+    // 연속 출석 일수
+    private final int continuousDay;
+
+    // 오늘 날짜
+    private final LocalDate today;
+
+    // 정적 팩토리 메서드
+    public static AttendanceStatusResponse of(boolean[] attendanceStatus, int continuousDays, LocalDate today) {
+        return new AttendanceStatusResponse(attendanceStatus, continuousDays, today);
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/attendance/entity/Attendance.java
+++ b/src/main/java/org/example/hugmeexp/domain/attendance/entity/Attendance.java
@@ -1,0 +1,53 @@
+package org.example.hugmeexp.domain.attendance.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.hugmeexp.global.entity.BaseEntity;
+import org.example.hugmeexp.global.entity.User;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@NoArgsConstructor(force = true) // final 필드가 있을 땐, force = true 로 final 필드도 0, null로 초기화 해주지 않으면 컴파일 에러가 난다고 합니다.
+@AllArgsConstructor(access = AccessLevel.PRIVATE) // 모든 필드를 파라미터로 바든ㄴ 생성자 생성, 생성자의 접근 제어자를 private로 만듦
+@Builder
+/*
+@Builder(builderMethodName = "hiddenBuilder") 이렇게 하면 정적 팩토리 메서드로만 객체 생성이 가능하다고 합니다.
+그냥 @Builder만 쓰면 누구나 Attendance.builder()로 객체를 만들 수 있어서,
+정적 팩토리 메서드만 사용 하자는 팀 규칙에 hiddenBuilder가 더 적합할 수도 있을 것 같은데 일단 보류해놓겠습니다.
+ */
+@Table(name = "attendance")
+public class Attendance extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // JPA에서 관리하는 id, 이거 생성 안 해두면 나중에 jpa 에서 엔티티 저장/조회 시 에러 난다고 함
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private final Long userName;
+
+    @Column(nullable = false)
+    private final LocalDate attendanceDate;
+
+    @Column(nullable = false)
+    private final int exp;
+
+    @Column(nullable = false)
+    private final int point;
+
+    // 정적 팩토리 메서드
+    public static Attendance of(User user, LocalDate attendanceDate, int exp, int point) {
+        return Attendance.builder()
+                .user(user)
+                .attendanceDate(attendanceDate)
+                .exp(exp)
+                .point(point)
+                .build();
+    }
+}
+

--- a/src/main/java/org/example/hugmeexp/domain/attendance/repository/AttendanceRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/attendance/repository/AttendanceRepository.java
@@ -1,0 +1,14 @@
+package org.example.hugmeexp.domain.attendance.repository;
+
+import org.example.hugmeexp.domain.attendance.entity.Attendance;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
+
+    // 유저 id와 일주일간 출석정보 조회
+    List<Attendance> findByUserIdAndAttendanceDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
+
+}

--- a/src/main/java/org/example/hugmeexp/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/org/example/hugmeexp/domain/attendance/service/AttendanceService.java
@@ -1,0 +1,71 @@
+package org.example.hugmeexp.domain.attendance.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.hugmeexp.domain.attendance.dto.AttendanceCheckRequest;
+import org.example.hugmeexp.domain.attendance.dto.AttendanceCheckResponse;
+import org.example.hugmeexp.domain.attendance.dto.AttendanceStatusResponse;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceService {
+
+    // 예시: 유저별 출석일 저장 (실제 환경에서는 DB 사용)
+    private final Map<Long, Set<LocalDate>> attendanceData = new HashMap<>();
+
+    // 일주일 출석 여부 조회
+    public AttendanceStatusResponse getAttendanceStatus(Long userId) {
+        Set<LocalDate> userAttendance = attendanceData.getOrDefault(userId, new HashSet<>());
+        boolean[] attendanceStatus = new boolean[7];
+        LocalDate today = LocalDate.now();
+
+        // 최근 7일(오늘 포함) 출석 여부
+        for (int i = 0; i < 7; i++) {
+            LocalDate date = today.minusDays(6 - i);
+            attendanceStatus[i] = userAttendance.contains(date);
+        }
+
+        // 연속 출석일 계산 (오늘부터 과거로)
+        int continuousDay = 0;
+        for (int i = 0; i < 7; i++) {
+            LocalDate date = today.minusDays(i);
+            if (userAttendance.contains(date)) {
+                continuousDay++;
+            } else {
+                break;
+            }
+        }
+
+        return AttendanceStatusResponse.of(attendanceStatus, continuousDay, today);
+    }
+
+    public AttendanceCheckResponse checkAttendance(Long userId, AttendanceCheckRequest request) {
+        Set<LocalDate> userAttendance = attendanceData.computeIfAbsent(userId, k -> new HashSet<>());
+        LocalDate today = LocalDate.now();
+
+        boolean alreadyChecked = userAttendance.contains(today);
+
+        if (alreadyChecked) {
+            return AttendanceCheckResponse.builder()
+                    .attend(false)
+                    .exp(0)
+                    .point(0)
+                    .build();
+        }
+
+        // 출석 처리
+        userAttendance.add(today);
+
+        return AttendanceCheckResponse.builder()
+                .attend(true)
+                .exp(31)
+                .point(1)
+                .build();
+    }
+}

--- a/src/test/java/org/example/hugmeexp/config/TestSecurityConfig.java
+++ b/src/test/java/org/example/hugmeexp/config/TestSecurityConfig.java
@@ -1,0 +1,21 @@
+package org.example.hugmeexp.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+/*
+테스트 할 때, 인증/인가 무시하고 사용하려고 만든 클래스입니다.
+attendance test 클래스에서 사용했으니 추후 삭제하거나 가져다 쓰시면 될 것 같습니다.
+ */
+@TestConfiguration
+public class TestSecurityConfig {
+    @Bean
+    public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/src/test/java/org/example/hugmeexp/domain/attendance/controller/AttendanceControllerTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/attendance/controller/AttendanceControllerTest.java
@@ -1,0 +1,80 @@
+package org.example.hugmeexp.domain.attendance.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.hugmeexp.config.TestSecurityConfig;
+import org.example.hugmeexp.domain.attendance.dto.AttendanceCheckRequest;
+import org.example.hugmeexp.domain.attendance.dto.AttendanceCheckResponse;
+import org.example.hugmeexp.domain.attendance.dto.AttendanceStatusResponse;
+import org.example.hugmeexp.domain.attendance.service.AttendanceService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AttendanceController.class)
+@Import(TestSecurityConfig.class)
+class AttendanceControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AttendanceService attendanceService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("출석 상태 조회 API 테스트")
+    void getAttendanceStatus() throws Exception {
+        // given
+        Long userId = 1L;
+        boolean[] attendanceStatus = {true, false, false, false, false, false, false};
+        int continuousDay = 1;
+        LocalDate today = LocalDate.of(2024, 6, 19);
+        AttendanceStatusResponse response = AttendanceStatusResponse.of(attendanceStatus, continuousDay, today);
+        Mockito.when(attendanceService.getAttendanceStatus(userId)).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/attendance")
+                        .param("userId", String.valueOf(userId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.attendanceStatus[0]").value(true))
+                .andExpect(jsonPath("$.continuousDay").value(1))
+                .andExpect(jsonPath("$.today").value("2024-06-19"));
+    }
+
+    @Test
+    @DisplayName("출석 체크 API 테스트")
+    void checkAttendance() throws Exception {
+        // given
+        Long userId = 1L;
+        AttendanceCheckRequest request = new AttendanceCheckRequest(userId);
+        AttendanceCheckResponse response = AttendanceCheckResponse.of(true, 2, 100);
+        Mockito.when(attendanceService.checkAttendance(eq(userId), any(AttendanceCheckRequest.class))).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/attendance/check")
+                        .param("userId", String.valueOf(userId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.attend").value(true))
+                .andExpect(jsonPath("$.exp").value(2))
+                .andExpect(jsonPath("$.point").value(100));
+    }
+}

--- a/src/test/java/org/example/hugmeexp/domain/attendance/service/AttendanceServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/attendance/service/AttendanceServiceTest.java
@@ -1,0 +1,66 @@
+package org.example.hugmeexp.domain.attendance.service;
+
+import org.example.hugmeexp.domain.attendance.dto.AttendanceCheckRequest;
+import org.example.hugmeexp.domain.attendance.dto.AttendanceCheckResponse;
+import org.example.hugmeexp.domain.attendance.dto.AttendanceStatusResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AttendanceServiceTest {
+
+    @Test
+    @DisplayName("출석 상태 조회 서비스 테스트")
+    void getAttendanceStatus() {
+        // given
+        AttendanceService service = new AttendanceService();
+        Long userId = 1L;
+        LocalDate today = LocalDate.now();
+
+        // 출석 3일 연속 체크
+        for (int i = 0; i < 3; i++) {
+            LocalDate date = today.minusDays(i);
+            service.checkAttendance(userId, new AttendanceCheckRequest(userId));
+        }
+
+        // when
+        AttendanceStatusResponse response = service.getAttendanceStatus(userId);
+
+        // then
+        assertThat(response.getContinuousDay()).isGreaterThanOrEqualTo(1);
+        assertThat(response.getToday()).isEqualTo(today);
+        assertThat(response.getAttendanceStatus()).hasSize(7);
+    }
+
+    @Test
+    @DisplayName("출석 체크 서비스 테스트 - 첫 출석")
+    void checkAttendance_first() {
+        AttendanceService service = new AttendanceService();
+        Long userId = 2L;
+
+        AttendanceCheckResponse response = service.checkAttendance(userId, new AttendanceCheckRequest(userId));
+
+        assertThat(response.isAttend()).isTrue();
+        assertThat(response.getExp()).isEqualTo(31);
+        assertThat(response.getPoint()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("출석 체크 서비스 테스트 - 이미 출석한 경우")
+    void checkAttendance_alreadyChecked() {
+        AttendanceService service = new AttendanceService();
+        Long userId = 3L;
+
+        // 첫 출석
+        service.checkAttendance(userId, new AttendanceCheckRequest(userId));
+        // 같은 날 재출석 시도
+        AttendanceCheckResponse response = service.checkAttendance(userId, new AttendanceCheckRequest(userId));
+
+        assertThat(response.isAttend()).isFalse();
+        assertThat(response.getExp()).isEqualTo(0);
+        assertThat(response.getPoint()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
### 구현한 api
- 출석 상태 조회: getAttendanceStatus
- 출석 체크: checkAttendance

### 다른 분들이 아시면 좋을 것
- 테스트 할 때, 인증/인가 필요 없게 하려고 test 하위에 config/TestSecurityConfig를 만들어 사용하였습니다. @import(TestSecurityConfig.class) 이런식으로 클래스 바로 위에 붙여서 사용하였습니다. 문제가 될 시 추후 삭제하겠습니다.
- 기존에 문제가 되었던, main 브랜치에서 파생됐던 저의 feature/attendance 브랜치를 삭제하고, develop 브랜치에서 새 feature/attendance 브랜치를 만들었습니다. git clone 부터 새로 해와서 제 도메인 복붙하여 완성하였고, 빌드 문제 없는 것 확인했습니다!

### 앞으로 할 일
- 현재 출석 상태 조회가, 오늘을 기준으로 6일전까지 해서 조회하는 걸로 되어있습니다. 이걸 이제 오늘이 기준이 되는게 아니라, 실제 달력을 불러와서 일요일~토요일 단위로 일주일 씩 끊어서 출석을 조회하는 걸로 변경할 예정입니다.
- 정적 팩토리 메서드해(of) 사용이나 빌더 패턴 사용을 잘 하려고 해봤는데, 미숙해서 앞으로 좀 더 리팩토링이 필요할 것 같습니다.
- 커스텀 예외처리가 있는지 고찰 후 필요하면 추가할 예정입니다.
- swagger 작성 예정입니다.

---
<img width="1392" alt="1" src="https://github.com/user-attachments/assets/55af2204-0692-4f2f-b836-05100073ec76" />
[출석체크 등록 완료]

<img width="1392" alt="2" src="https://github.com/user-attachments/assets/d8168bde-5cd7-424d-9cd4-f72cc881c8b2" />
[출석 상태 조회: 오늘 출석체크를 완료한 시점이므로, attendanceStatus 중 오늘인 맨 마지막 index만 true로 되어있습니다.]
