### PR TITLE
feat: 상품 주문 이력 조회 구현

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/shop/controller/ProductAdminController.java
+++ b/src/main/java/org/example/hugmeexp/domain/shop/controller/ProductAdminController.java
@@ -12,11 +12,9 @@ import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 
-//TODO '/api/v1/shop' -> '/api/v1/admin/shop' (관리자 권한 때문에 경로 수정해놓음)
-
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/shop")
+@RequestMapping("/api/v1/admin/shop")
 @Slf4j
 public class ProductAdminController {
 

--- a/src/main/java/org/example/hugmeexp/domain/shop/controller/ProductController.java
+++ b/src/main/java/org/example/hugmeexp/domain/shop/controller/ProductController.java
@@ -2,16 +2,20 @@ package org.example.hugmeexp.domain.shop.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.hugmeexp.domain.shop.dto.OrderResponse;
 import org.example.hugmeexp.domain.shop.dto.ProductResponse;
 import org.example.hugmeexp.domain.shop.dto.PurchaseRequest;
 import org.example.hugmeexp.domain.shop.dto.PurchaseResponse;
 import org.example.hugmeexp.domain.shop.service.ProductService;
+import org.example.hugmeexp.domain.user.entity.User;
 import org.example.hugmeexp.global.common.response.Response;
 import org.example.hugmeexp.global.security.CustomUserDetails;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -27,8 +31,12 @@ public class ProductController {
      * @return
      */
     @GetMapping
-    public ResponseEntity<Response<?>> getAllProducts() {
-        List<ProductResponse> allProduct = productService.getAllProducts();
+    public ResponseEntity<Response<?>> getAllProducts(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        User user = userDetails.getUser();
+        log.info("login user: {}", user.getUsername());
+        List<ProductResponse> allProduct = productService.getAllProducts(user);
         return ResponseEntity.ok().body(Response.builder().data(allProduct).message("Successfully retrieved all products.").build());
     }
 
@@ -51,6 +59,34 @@ public class ProductController {
         String purchaserUsername = userDetails.getUsername();
         PurchaseResponse response = productService.purchase(purchaserUsername, request);
         return ResponseEntity.ok().body(Response.builder().data(response).message("Successfully purchased product.").build());
+    }
+
+    /**
+     * 주문 내역 조회
+     * @param startDate
+     * @param endDate
+     * @param userDetails
+     * @return
+     */
+    @GetMapping("/history")
+    public ResponseEntity<Response<?>> getOrders(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        if (endDate == null) {
+            endDate = LocalDate.now();
+        }
+        if (startDate == null) {
+            startDate = endDate.minusMonths(1);
+        }
+        User user = userDetails.getUser();
+
+        log.info("start date: {}", startDate);
+        log.info("end date: {}", endDate);
+
+        List<OrderResponse> response = productService.getOrders(user, startDate, endDate);
+        return ResponseEntity.ok().body(Response.builder().data(response).message("Successfully retrieved orders.").build());
     }
 
 

--- a/src/main/java/org/example/hugmeexp/domain/shop/controller/ProductController.java
+++ b/src/main/java/org/example/hugmeexp/domain/shop/controller/ProductController.java
@@ -89,11 +89,10 @@ public class ProductController {
         return ResponseEntity.ok().body(Response.builder().data(response).message("Successfully retrieved orders.").build());
     }
 
-
-    // ===== 사용자 구매 테스트를 위한 포인트 증가 메서드 =====
-    @PostMapping("/point")
-    public void increasePoint(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        productService.increasePoint(userDetails.getUsername());
-    }
+//    // ===== 사용자 구매 테스트를 위한 포인트 증가 메서드 =====
+//    @PostMapping("/point")
+//    public void increasePoint(
+//            @AuthenticationPrincipal CustomUserDetails userDetails) {
+//        productService.increasePoint(userDetails.getUsername());
+//    }
 }

--- a/src/main/java/org/example/hugmeexp/domain/shop/dto/OrderResponse.java
+++ b/src/main/java/org/example/hugmeexp/domain/shop/dto/OrderResponse.java
@@ -1,0 +1,20 @@
+package org.example.hugmeexp.domain.shop.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderResponse {
+
+    private String imageUrl;
+    private String brand;
+    private String name;
+    private String price;
+    private LocalDateTime orderTime;
+    private String receiverPhoneNumber;
+}

--- a/src/main/java/org/example/hugmeexp/domain/shop/dto/ProductResponse.java
+++ b/src/main/java/org/example/hugmeexp/domain/shop/dto/ProductResponse.java
@@ -14,7 +14,10 @@ public class ProductResponse {
     private Long id;
     private String name;
     private String brand;
-    private String quantity;
-    private String price;
+    private int quantity;
+    private int price;
     private String imageUrl;
+
+    // 로그인 사용자가 구매 가능한 상품인지
+    private boolean available = false;
 }

--- a/src/main/java/org/example/hugmeexp/domain/shop/entity/Order.java
+++ b/src/main/java/org/example/hugmeexp/domain/shop/entity/Order.java
@@ -20,7 +20,7 @@ public class Order extends BaseEntity {
 
     // Order와 User는 N:1 관계이고 Order -> User의 단방향 매핑
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "purchaser_id", nullable = false)
     private User user;
 
     // Order와 Product는 N:1 관계이고 Order -> Product의 단방향 매핑
@@ -29,13 +29,13 @@ public class Order extends BaseEntity {
     private Product product;
 
     @Column(nullable = false, length = 13)
-    private String phoneNumber;
+    private String receiverPhoneNumber;
 
     @Builder
     private Order(User user, Product product, String phoneNumber) {
         this.user = user;
         this.product = product;
-        this.phoneNumber = phoneNumber;
+        this.receiverPhoneNumber = phoneNumber;
     }
 
     // 정적 팩토리 메서드

--- a/src/main/java/org/example/hugmeexp/domain/shop/repository/OrderRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/shop/repository/OrderRepository.java
@@ -1,7 +1,12 @@
 package org.example.hugmeexp.domain.shop.repository;
 
 import org.example.hugmeexp.domain.shop.entity.Order;
+import org.example.hugmeexp.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface OrderRepository extends JpaRepository<Order, Long> {
+    List<Order> findAllByUserAndCreatedAtBetween(User user, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/org/example/hugmeexp/domain/shop/service/ProductService.java
+++ b/src/main/java/org/example/hugmeexp/domain/shop/service/ProductService.java
@@ -3,11 +3,13 @@ package org.example.hugmeexp.domain.shop.service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.hugmeexp.domain.shop.dto.OrderResponse;
 import org.example.hugmeexp.domain.shop.dto.ProductResponse;
 import org.example.hugmeexp.domain.shop.dto.PurchaseRequest;
 import org.example.hugmeexp.domain.shop.dto.PurchaseResponse;
 import org.example.hugmeexp.domain.shop.entity.Order;
 import org.example.hugmeexp.domain.shop.entity.Product;
+import org.example.hugmeexp.domain.shop.entity.ProductImage;
 import org.example.hugmeexp.domain.shop.exception.*;
 import org.example.hugmeexp.domain.shop.mapper.ProductMapper;
 import org.example.hugmeexp.domain.shop.repository.OrderRepository;
@@ -16,6 +18,8 @@ import org.example.hugmeexp.domain.user.repository.UserRepository;
 import org.example.hugmeexp.domain.user.entity.User;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -34,12 +38,21 @@ public class ProductService {
      * - 삭제된 상품은 조회되지 않음
      * @return
      */
-    public List<ProductResponse> getAllProducts() {
+    public List<ProductResponse> getAllProducts(User user) {
 
         log.info("전체 상품 조회 요청");
-        return productRepository.findAllByIsDeletedFalse().stream()
+
+        // 삭제되지 않은 상품들에 대해 Product -> ProductResonse 변환
+        List<ProductResponse> response = productRepository.findAllByIsDeletedFalse().stream()
                 .map(productMapper::toResponse)
                 .collect(Collectors.toList());
+
+        // 로그인한 사용자가 구매 가능한 상품인지 설정
+        for (ProductResponse productResponse : response) {
+            if (productResponse.getPrice() <= user.getPoint()) productResponse.setAvailable(true);
+        }
+
+        return response;
     }
 
     /**
@@ -90,6 +103,7 @@ public class ProductService {
                 receiver.getPhoneNumber()
         );
 
+        // 구매자 포인트 및 상품 재고 감소
         purchaser.increasePoint(product.getPrice() * (-1));
         product.decreaseQuantity();
 
@@ -102,12 +116,49 @@ public class ProductService {
                 .remainingPoint(purchaser.getPoint())
                 .productName(product.getName())
                 .productQuantity(product.getQuantity())
-                .phoneNumber(order.getPhoneNumber())
+                .phoneNumber(order.getReceiverPhoneNumber())
                 .purchaseTime(order.getCreatedAt())
                 .build();
         return response;
     }
 
+
+    public List<OrderResponse> getOrders(User user, LocalDate startDate, LocalDate endDate) {
+
+        // 입력 데이터는 날짜 정보만 있으므로 시:분:초를 포함하도록 수정
+        LocalDateTime startDateTime = startDate.atStartOfDay();
+        LocalDateTime endDateTime = endDate.plusDays(1).atStartOfDay();
+
+        // 유저, 시작 시간, 종료 시간으로 Order 필터링
+        List<Order> orders = orderRepository.findAllByUserAndCreatedAtBetween(user, startDateTime, endDateTime);
+
+        // Order -> OrderResponse 변환 후 반환
+        return orders.stream()
+                .map(this::toOrderResponse)
+                .collect(Collectors.toList());
+    }
+
+
+    // ===== private method =====
+    private OrderResponse toOrderResponse(Order order) {
+
+        Product product = order.getProduct();
+        ProductImage image = product.getProductImage();
+
+        String imageUrl = null;
+        if (image != null) {
+            imageUrl = String.format("%s\\%s.%s", image.getPath(), image.getUuid(), image.getExtension());
+        }
+
+        return OrderResponse.builder()
+                .imageUrl(imageUrl)
+                .brand(product.getBrand())
+                .name(product.getName())
+                .price(String.format("%d 포인트", product.getPrice()))
+                .orderTime(order.getCreatedAt())
+                .receiverPhoneNumber(order.getReceiverPhoneNumber())
+                .build();
+    }
 
     // ===== 테스트용 =====
     public void increasePoint(String username) {


### PR DESCRIPTION
## 구현 내용
- 로그인한 사용자의 주문 이력 조회
- 사용자 데이터와 날짜를 입력받아 Order 엔티티 필터링 후 DTO 변환 및 응답
- 전체 상품 조회 시 각 상품에 대한 사용자의 구매 가능 여부도 응답하도록 ProductDTO 수정

## 수정 사항
- 테스트용으로 /shop 경로로 열어뒀던 관리자 기능을 /admin/shop 경로로 수정하고 테스트 메서드를 주석처리 하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 사용자가 지정한 기간 내 주문 내역을 조회할 수 있는 주문 내역 조회 기능이 추가되었습니다.
- **기능 개선**
    - 상품 목록 조회 시 로그인한 사용자의 포인트에 따라 구매 가능 여부가 표시됩니다.
    - 상품 및 주문 관련 엔드포인트가 사용자 정보와 날짜 필터링을 지원하도록 개선되었습니다.
- **API 변경**
    - 관리자 전용 상품 관리 API의 기본 경로가 `/api/v1/admin/shop`으로 변경되었습니다.
    - 주문 관련 DTO 및 엔티티 필드명이 일부 변경되었습니다(예: 수령인 전화번호 등).
- **기타**
    - 일부 사용하지 않는 포인트 증가 API가 비활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->