### PR TITLE
feat: 회원 권한 수정, 회원 상세 정보 조회

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/user/controller/ProfileImageDeleteController.java
+++ b/src/main/java/org/example/hugmeexp/domain/user/controller/ProfileImageDeleteController.java
@@ -23,6 +23,6 @@ public class ProfileImageDeleteController {
         User user = userDetails.getUser();
         userService.deleteProfileImage(user);
 
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.noContent().build(); // 204 No Content
     }
 }

--- a/src/main/java/org/example/hugmeexp/domain/user/controller/ProfileImageRegisterController.java
+++ b/src/main/java/org/example/hugmeexp/domain/user/controller/ProfileImageRegisterController.java
@@ -26,11 +26,11 @@ public class ProfileImageRegisterController {
             @RequestPart("file") MultipartFile file, @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         User user = userDetails.getUser();
-        String fullPath = userService.registerProfileImage(user, file);
+        ProfileImageResponse result = userService.registerProfileImage(user, file);
 
         return ResponseEntity.ok(Response.<ProfileImageResponse>builder()
                 .message("프로필 이미지가 등록되었습니다.")
-                .data(new ProfileImageResponse(fullPath))
+                .data(result)
                 .build());
     }
 }

--- a/src/main/java/org/example/hugmeexp/domain/user/controller/UserInfoController.java
+++ b/src/main/java/org/example/hugmeexp/domain/user/controller/UserInfoController.java
@@ -1,0 +1,34 @@
+package org.example.hugmeexp.domain.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.hugmeexp.domain.user.dto.response.UserInfoResponse;
+import org.example.hugmeexp.domain.user.entity.User;
+import org.example.hugmeexp.domain.user.mapper.UserResponseMapper;
+import org.example.hugmeexp.domain.user.service.UserService;
+import org.example.hugmeexp.global.common.response.Response;
+import org.example.hugmeexp.global.security.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class UserInfoController {
+
+    private final UserService userService;
+
+    @GetMapping("/api/v1/user")
+    public ResponseEntity<Response<UserInfoResponse>> getUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        User user = userService.findById(userDetails.getUser().getId());
+        UserInfoResponse result = UserResponseMapper.toUserInfoResponse(user);
+
+        return ResponseEntity.ok(Response.<UserInfoResponse>builder()
+                .message("회원 정보를 불러왔습니다.")
+                .data(result)
+                .build());
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/user/controller/UserRoleChangeController.java
+++ b/src/main/java/org/example/hugmeexp/domain/user/controller/UserRoleChangeController.java
@@ -1,0 +1,26 @@
+package org.example.hugmeexp.domain.user.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.hugmeexp.domain.user.dto.request.ChangeRoleRequest;
+import org.example.hugmeexp.domain.user.service.UserService;
+import org.example.hugmeexp.global.common.response.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class UserRoleChangeController {
+
+    private final UserService userService;
+
+    @PostMapping("/api/v1/admin/change-role")
+    public ResponseEntity<Response<Void>> changeRole(@Valid @RequestBody ChangeRoleRequest request) {
+        userService.changeUserRole(request);
+        return ResponseEntity.noContent().build(); // 204 No Content
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/user/dto/request/ChangeRoleRequest.java
+++ b/src/main/java/org/example/hugmeexp/domain/user/dto/request/ChangeRoleRequest.java
@@ -1,0 +1,23 @@
+package org.example.hugmeexp.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.hugmeexp.domain.user.enums.UserRole;
+
+@Getter
+@NoArgsConstructor
+public class ChangeRoleRequest {
+
+    @NotBlank
+    private String username;
+
+    @NotNull
+    private UserRole role;
+
+    public ChangeRoleRequest(String username, UserRole role) {
+        this.username = username;
+        this.role = role;
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/user/dto/request/UserUpdateRequest.java
+++ b/src/main/java/org/example/hugmeexp/domain/user/dto/request/UserUpdateRequest.java
@@ -3,14 +3,15 @@ package org.example.hugmeexp.domain.user.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
+@Builder
 @Getter
-@Setter
-@NoArgsConstructor
+@AllArgsConstructor
 public class UserUpdateRequest {
+
     @NotBlank
     @Size(min = 2, max = 32)
     private String name;

--- a/src/main/java/org/example/hugmeexp/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/org/example/hugmeexp/domain/user/dto/response/UserInfoResponse.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class UserInfoResponse {
-    private final String profileImagePath;
+    private final String profileImage;
     private final String name;
     private final String description;
     private final String phoneNumber;

--- a/src/main/java/org/example/hugmeexp/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/org/example/hugmeexp/domain/user/dto/response/UserProfileResponse.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class UserProfileResponse {
-    private final String profileImagePath;
+    private final String profileImage;
     private final String username;
     private final String name;
 }

--- a/src/main/java/org/example/hugmeexp/domain/user/entity/User.java
+++ b/src/main/java/org/example/hugmeexp/domain/user/entity/User.java
@@ -102,7 +102,7 @@ public class User extends BaseEntity {
     // 구름조각 감소
     public void decreasePoint(int value) {
         if(value <= 0) throw new InvalidValueException("양수만 요청할 수 있습니다.");
-        if(this.getPoint() - value < 0) throw new InvalidValueException("구름조각은 음수가 될 수 없습니다.");
+        if(this.point - value < 0) throw new InvalidValueException("구름조각은 음수가 될 수 없습니다.");
         log.info("point decrease - user: {}({}) {} -> {}", this.username, this.name, this.point, this.point - value);
         this.point -= value;
     }

--- a/src/main/java/org/example/hugmeexp/domain/user/mapper/UserResponseMapper.java
+++ b/src/main/java/org/example/hugmeexp/domain/user/mapper/UserResponseMapper.java
@@ -1,5 +1,6 @@
 package org.example.hugmeexp.domain.user.mapper;
 
+import org.example.hugmeexp.domain.user.dto.response.ProfileImageResponse;
 import org.example.hugmeexp.domain.user.dto.response.UserInfoResponse;
 import org.example.hugmeexp.domain.user.dto.response.UserProfileResponse;
 import org.example.hugmeexp.domain.user.entity.User;
@@ -22,6 +23,12 @@ public class UserResponseMapper {
                 user.getFullProfileImagePath(),
                 user.getUsername(),
                 user.getName()
+        );
+    }
+
+    public static ProfileImageResponse toProfileImageResponse(User user) {
+        return new ProfileImageResponse(
+                user.getFullProfileImagePath()
         );
     }
 }

--- a/src/main/java/org/example/hugmeexp/global/infra/auth/dto/request/LoginRequest.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/dto/request/LoginRequest.java
@@ -3,10 +3,10 @@ package org.example.hugmeexp.global.infra.auth.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@NoArgsConstructor
 public class LoginRequest {
 
     @NotBlank
@@ -16,4 +16,9 @@ public class LoginRequest {
     @NotBlank
     @Size(min = 8, max = 60)
     private String password;
+
+    public LoginRequest(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
 }

--- a/src/main/java/org/example/hugmeexp/global/infra/auth/dto/request/RefreshRequest.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/dto/request/RefreshRequest.java
@@ -2,14 +2,13 @@ package org.example.hugmeexp.global.infra.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter @Setter
-@AllArgsConstructor
+@Getter
+@NoArgsConstructor
 public class RefreshRequest {
+
     @NotBlank
     @Size(min = 10)
     private String accessToken;
@@ -17,4 +16,9 @@ public class RefreshRequest {
     @NotBlank
     @Size(min = 10)
     private String refreshToken;
+
+    public RefreshRequest(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/org/example/hugmeexp/global/infra/auth/dto/request/RegisterRequest.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/dto/request/RegisterRequest.java
@@ -5,12 +5,11 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
 @NoArgsConstructor
 public class RegisterRequest {
+
     @NotBlank
     @Size(min = 4, max = 32)
     private String username;
@@ -26,4 +25,11 @@ public class RegisterRequest {
     @NotBlank
     @Pattern(regexp = "^01[0-9]-\\d{4}-\\d{4}$")
     private String phoneNumber;
+
+    public RegisterRequest(String username, String password, String name, String phoneNumber) {
+        this.username = username;
+        this.password = password;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+    }
 }

--- a/src/test/java/org/example/hugmeexp/global/auth/controller/LoginControllerTest.java
+++ b/src/test/java/org/example/hugmeexp/global/auth/controller/LoginControllerTest.java
@@ -32,8 +32,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayName("로그인 컨트롤러 테스트")
 @TestPropertySource(properties = {
         "jwt.secret=aHR0cHM6Ly9naXRodWIuY29tL3NldW5nd29vay9qd3QtYXBpLXNlcnZlci1zYW1wbGUteW91LWNhbi11c2UtdGhpcy1sb25nLXNlY3JldC1rZXktZm9yLWVuY3J5cHRpb24K",
-        "jwt.access-token-expiration=1800000",
-        "jwt.refresh-token-expiration=604800000"
+        "jwt.access-token-expiration=10000",
+        "jwt.refresh-token-expiration=60000"
 })
 class LoginControllerTest {
 
@@ -57,7 +57,7 @@ class LoginControllerTest {
 
     @AfterEach
     void tearDown() {
-        userService.deleteByUsername("testuser"); // 반드시 UserService에 해당 메서드 존재해야 함
+        userService.deleteByUsername("testuser");
     }
 
     @Test
@@ -75,8 +75,7 @@ class LoginControllerTest {
         resultActions
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
-                .andExpect(jsonPath("$.data.refreshToken").isNotEmpty())
-                .andExpect(jsonPath("$.message").value("로그인에 성공했습니다"));
+                .andExpect(jsonPath("$.data.refreshToken").isNotEmpty());
     }
 
     @Test
@@ -92,8 +91,7 @@ class LoginControllerTest {
 
         // then
         resultActions
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.message").value("아이디 또는 비밀번호가 잘못되었습니다."));
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -109,7 +107,6 @@ class LoginControllerTest {
 
         // then
         resultActions
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.message").value("아이디 또는 비밀번호가 잘못되었습니다."));
+                .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/org/example/hugmeexp/global/auth/controller/LoginControllerTest.java
+++ b/src/test/java/org/example/hugmeexp/global/auth/controller/LoginControllerTest.java
@@ -51,12 +51,7 @@ class LoginControllerTest {
 
     @BeforeEach
     void setUp() {
-        RegisterRequest request = new RegisterRequest();
-        request.setUsername("testuser");
-        request.setPassword("testpassword1!");
-        request.setName("홍길동");
-        request.setPhoneNumber("010-1234-5678");
-
+        RegisterRequest request = new RegisterRequest("testuser", "testpassword1!", "홍길동", "010-1234-5678");
         credentialService.registerNewUser(request);
     }
 
@@ -69,9 +64,7 @@ class LoginControllerTest {
     @DisplayName("로그인 성공시 토큰이 응답된다.")
     void shouldReturnTokens_whenLoginIsSuccessful() throws Exception {
         // given
-        LoginRequest request = new LoginRequest();
-        request.setUsername("testuser");
-        request.setPassword("testpassword1!");
+        LoginRequest request = new LoginRequest("testuser", "testpassword1!");
 
         // when
         ResultActions resultActions = mockMvc.perform(post("/api/login")
@@ -90,9 +83,7 @@ class LoginControllerTest {
     @DisplayName("존재하지 않는 아이디를 입력하면 실패한다.")
     void shouldFailLogin_whenUserDoesNotExist() throws Exception {
         // given
-        LoginRequest request = new LoginRequest();
-        request.setUsername("notexist");
-        request.setPassword("testpassword1!");
+        LoginRequest request = new LoginRequest("notexist", "testpassword1!");
 
         // when
         ResultActions resultActions = mockMvc.perform(post("/api/login")
@@ -109,9 +100,7 @@ class LoginControllerTest {
     @DisplayName("틀린 비밀번호를 입력하면 실패한다.")
     void shouldFailLogin_whenPasswordIsIncorrect() throws Exception {
         // given
-        LoginRequest request = new LoginRequest();
-        request.setUsername("testuser");
-        request.setPassword("wrongpassword");
+        LoginRequest request = new LoginRequest("testuser", "wrongpassword");
 
         // when
         ResultActions resultActions = mockMvc.perform(post("/api/login")

--- a/src/test/java/org/example/hugmeexp/global/auth/controller/LogoutControllerTest.java
+++ b/src/test/java/org/example/hugmeexp/global/auth/controller/LogoutControllerTest.java
@@ -1,0 +1,62 @@
+package org.example.hugmeexp.global.auth.controller;
+
+import org.example.hugmeexp.domain.user.service.UserService;
+import org.example.hugmeexp.global.infra.auth.dto.request.LoginRequest;
+import org.example.hugmeexp.global.infra.auth.dto.request.RegisterRequest;
+import org.example.hugmeexp.global.infra.auth.dto.response.AuthResponse;
+import org.example.hugmeexp.global.infra.auth.service.AuthService;
+import org.example.hugmeexp.global.infra.auth.service.CredentialService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("로그아웃 컨트롤러 테스트")
+@TestPropertySource(properties = {
+        "jwt.secret=aHR0cHM6Ly9naXRodWIuY29tL3NldW5nd29vay9qd3QtYXBpLXNlcnZlci1zYW1wbGUteW91LWNhbi11c2UtdGhpcy1sb25nLXNlY3JldC1rZXktZm9yLWVuY3J5cHRpb24K",
+        "jwt.access-token-expiration=10000",
+        "jwt.refresh-token-expiration=60000"
+})
+class LogoutControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired private AuthService authService;
+    @Autowired private CredentialService credentialService;
+    @Autowired private UserService userService;
+
+    private final String username = "logoutuser";
+    private final String phone = "010-2222-3333";
+    private final String password = "logout123!";
+
+    @AfterEach
+    void tearDown() {
+        userService.deleteByUsername(username);
+    }
+
+    @Test
+    @DisplayName("액세스 토큰을 포함한 요청으로 로그아웃하면 200 상태코드를 반환한다.")
+    void shouldReturnOk_whenLogoutSuccessfully() throws Exception {
+        // given
+        RegisterRequest registerRequest = new RegisterRequest(username, password, "강호동", phone);
+        credentialService.registerNewUser(registerRequest);
+
+        LoginRequest loginRequest = new LoginRequest(username, password);
+        AuthResponse tokens = authService.login(loginRequest);
+
+        // when
+        mockMvc.perform(post("/api/logout")
+                        .header("Authorization", "Bearer " + tokens.getAccessToken()))
+                // then
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/org/example/hugmeexp/global/auth/controller/RefreshControllerTest.java
+++ b/src/test/java/org/example/hugmeexp/global/auth/controller/RefreshControllerTest.java
@@ -1,0 +1,110 @@
+package org.example.hugmeexp.global.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.hugmeexp.domain.user.exception.UserNotFoundException;
+import org.example.hugmeexp.domain.user.service.UserService;
+import org.example.hugmeexp.global.infra.auth.dto.request.LoginRequest;
+import org.example.hugmeexp.global.infra.auth.dto.request.RefreshRequest;
+import org.example.hugmeexp.global.infra.auth.dto.request.RegisterRequest;
+import org.example.hugmeexp.global.infra.auth.dto.response.AuthResponse;
+import org.example.hugmeexp.global.infra.auth.service.AuthService;
+import org.example.hugmeexp.global.infra.auth.service.CredentialService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("리프레시 토큰 컨트롤러 테스트")
+@TestPropertySource(properties = {
+        "jwt.secret=aHR0cHM6Ly9naXRodWIuY29tL3NldW5nd29vay9qd3QtYXBpLXNlcnZlci1zYW1wbGUteW91LWNhbi11c2UtdGhpcy1sb25nLXNlY3JldC1rZXktZm9yLWVuY3J5cHRpb24K",
+        "jwt.access-token-expiration=10000",
+        "jwt.refresh-token-expiration=60000"
+})
+class RefreshControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private AuthService authService;
+    @Autowired private CredentialService credentialService;
+    @Autowired private UserService userService;
+
+    private final String username = "refreshuser";
+    private final String phone = "010-3333-4444";
+    private final String password = "refresh123!";
+
+    @AfterEach
+    void tearDown() {
+        try {
+            userService.deleteByUsername("refreshuser");
+        } catch (UserNotFoundException e) {
+
+        }
+    }
+
+    @Test
+    @DisplayName("유효한 리프레시 토큰이 주어지면 새로운 access, refresh 토큰을 반환한다.")
+    void shouldReturnNewTokens_whenRefreshTokenIsValid() throws Exception {
+        // given
+        credentialService.registerNewUser(new RegisterRequest(username, password, "이순신", phone));
+        AuthResponse tokens = authService.login(new LoginRequest(username, password));
+
+        RefreshRequest request = new RefreshRequest(tokens.getAccessToken(), tokens.getRefreshToken());
+
+        Thread.sleep(1100);  // 액세스 토큰 만료 기다림
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.data.refreshToken").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 리프레시 토큰이 주어지면 401 상태코드를 반환한다.")
+    void shouldReturnUnauthorized_whenRefreshTokenIsInvalid() throws Exception {
+        // given
+        RefreshRequest request = new RefreshRequest("fake.access.token", "fake.refresh.token");
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("아직 만료되지 않은 액세스 토큰으로 리프레시 요청 시 400 상태코드를 반환한다.")
+    void shouldReturnBadRequest_whenAccessTokenIsStillValid() throws Exception {
+        // given
+        credentialService.registerNewUser(new RegisterRequest(username, password, "이순신", phone));
+        AuthResponse tokens = authService.login(new LoginRequest(username, password));
+
+        RefreshRequest request = new RefreshRequest(tokens.getAccessToken(), tokens.getRefreshToken());
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/org/example/hugmeexp/global/auth/controller/RegisterControllerTest.java
+++ b/src/test/java/org/example/hugmeexp/global/auth/controller/RegisterControllerTest.java
@@ -1,0 +1,117 @@
+package org.example.hugmeexp.global.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.hugmeexp.domain.user.exception.UserNotFoundException;
+import org.example.hugmeexp.domain.user.service.UserService;
+import org.example.hugmeexp.global.infra.auth.dto.request.RegisterRequest;
+import org.example.hugmeexp.global.infra.auth.service.CredentialService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("회원가입 컨트롤러 테스트")
+@TestPropertySource(properties = {
+        "jwt.secret=aHR0cHM6Ly9naXRodWIuY29tL3NldW5nd29vay9qd3QtYXBpLXNlcnZlci1zYW1wbGUteW91LWNhbi11c2UtdGhpcy1sb25nLXNlY3JldC1rZXktZm9yLWVuY3J5cHRpb24K",
+        "jwt.access-token-expiration=10000",
+        "jwt.refresh-token-expiration=60000"
+})
+class RegisterControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private CredentialService credentialService;
+    @Autowired private UserService userService;
+
+    private final String username = "newuser";
+    private final String phone = "010-1111-2222";
+
+    @AfterEach
+    void tearDown() {
+        try {
+            userService.deleteByUsername(username);
+        } catch (UserNotFoundException e) {
+            System.out.println("테스트 사용자 삭제 생략: " + e.getMessage());
+        }
+    }
+
+    @Test
+    @DisplayName("회원가입에 성공하면 200 상태코드와 토큰 정보를 반환한다.")
+    void shouldReturnOkAndTokens_whenRegisterUserSuccessfully() throws Exception {
+        // given
+        RegisterRequest request = new RegisterRequest(username, "validPass1!", "홍길동", phone);
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.data.refreshToken").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("중복된 사용자명으로 회원가입하면 409 상태코드를 반환한다.")
+    void shouldReturnConflict_whenUsernameIsDuplicated() throws Exception {
+        // given
+        RegisterRequest original = new RegisterRequest(username, "validPass1!", "홍길동", "010-9999-0000");
+        credentialService.registerNewUser(original);
+
+        RegisterRequest duplicateUsername = new RegisterRequest(username, "validPass1!", "홍길동", "010-8888-0000");
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(duplicateUsername)));
+
+        // then
+        result.andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("중복된 휴대폰 번호로 회원가입 요청을 하면 409 상태코드를 반환한다.")
+    void shouldReturnConflict_whenPhoneNumberIsDuplicated() throws Exception {
+        // given
+        RegisterRequest original = new RegisterRequest(username, "validPass1!", "홍길동", phone);
+        credentialService.registerNewUser(original);
+
+        RegisterRequest duplicatePhone = new RegisterRequest("anotherUser", "validPass1!", "이몽룡", phone);
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(duplicatePhone)));
+
+        // then
+        result.andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 입력으로 회원가입 요청을 하면 400 상태코드를 반환한다.")
+    void shouldReturnBadRequest_whenRequestIsInvalid() throws Exception {
+        // given
+        RegisterRequest invalid = new RegisterRequest("a", "123", "", "010");
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(invalid)));
+
+        // then
+        result.andExpect(status().isBadRequest());
+    }
+
+}

--- a/src/test/java/org/example/hugmeexp/global/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/global/auth/service/AuthServiceTest.java
@@ -1,0 +1,82 @@
+package org.example.hugmeexp.global.auth.service;
+
+import org.example.hugmeexp.domain.user.entity.User;
+import org.example.hugmeexp.domain.user.enums.UserRole;
+import org.example.hugmeexp.global.infra.auth.dto.request.LoginRequest;
+import org.example.hugmeexp.global.infra.auth.dto.request.RegisterRequest;
+import org.example.hugmeexp.global.infra.auth.dto.response.AuthResponse;
+import org.example.hugmeexp.global.infra.auth.service.AuthService;
+import org.example.hugmeexp.global.infra.auth.service.CredentialService;
+import org.example.hugmeexp.global.infra.auth.service.TokenService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;           // when(), verify(), any(), eq(), etc.
+import static org.mockito.BDDMockito.*;        // given(), willReturn(), willThrow(), etc.
+import static org.assertj.core.api.Assertions.*;  // assertThat(), assertThatThrownBy(), etc.
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private CredentialService credentialService;
+    @Mock private TokenService tokenService;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    @DisplayName("회원가입에 성공하면 accessToken과 refreshToken이 발급된다")
+    void shouldRegisterAndReturnTokens() {
+        // given
+        RegisterRequest request = new RegisterRequest("testuser", "raw1234!", "홍길동", "010-1234-5678");
+
+        User mockUser = User.createUser("testuser", "encodedPw", "홍길동", "010-1234-5678");
+
+        given(credentialService.registerNewUser(request)).willReturn(mockUser);
+        given(tokenService.createAccessToken("testuser", mockUser.getRole())).willReturn("access-token");
+        given(tokenService.createRefreshToken("testuser", mockUser.getRole())).willReturn("refresh-token");
+        given(tokenService.getTokenRemainingTimeMillis("refresh-token")).willReturn(3600000L);
+
+        // when
+        AuthResponse response = authService.registerAndAuthenticate(request);
+
+        // then
+        assertThat(response.getAccessToken()).isEqualTo("access-token");
+        assertThat(response.getRefreshToken()).isEqualTo("refresh-token");
+
+        verify(tokenService).saveRefreshToken("testuser", "refresh-token", 3600000L);
+    }
+
+    @Test
+    @DisplayName("로그인에 성공하면 기존 리프레시 토큰을 무효화하고 새로운 토큰을 발급한다")
+    void shouldLoginAndReturnNewTokens() {
+        // given
+        LoginRequest request = new LoginRequest("testuser", "raw1234!");
+
+        User mockUser = User.createUser("testuser", "encodedPw", "홍길동", "010-1234-5678");
+
+        given(credentialService.login(request)).willReturn(mockUser);
+        given(tokenService.getRefreshToken("testuser")).willReturn("old-refresh-token");
+        willDoNothing().given(tokenService).revokeRefreshToken("old-refresh-token");
+
+        given(tokenService.createAccessToken("testuser", mockUser.getRole())).willReturn("new-access-token");
+        given(tokenService.createRefreshToken("testuser", mockUser.getRole())).willReturn("new-refresh-token");
+        given(tokenService.getTokenRemainingTimeMillis("new-refresh-token")).willReturn(3600000L);
+
+        // when
+        AuthResponse response = authService.login(request);
+
+        // then
+        assertThat(response.getAccessToken()).isEqualTo("new-access-token");
+        assertThat(response.getRefreshToken()).isEqualTo("new-refresh-token");
+
+        verify(tokenService).revokeRefreshToken("old-refresh-token");
+        verify(tokenService).saveRefreshToken("testuser", "new-refresh-token", 3600000L);
+    }
+}
+

--- a/src/test/java/org/example/hugmeexp/global/auth/service/CredentialService/CredentialServiceLoginTest.java
+++ b/src/test/java/org/example/hugmeexp/global/auth/service/CredentialService/CredentialServiceLoginTest.java
@@ -1,0 +1,78 @@
+package org.example.hugmeexp.global.auth.service.CredentialService;
+
+import org.example.hugmeexp.domain.user.entity.User;
+import org.example.hugmeexp.domain.user.repository.UserRepository;
+import org.example.hugmeexp.global.infra.auth.dto.request.LoginRequest;
+import org.example.hugmeexp.global.infra.auth.exception.LoginFailedException;
+import org.example.hugmeexp.global.infra.auth.service.CredentialService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.*;        // given(), willReturn(), willThrow(), etc.
+import static org.assertj.core.api.Assertions.*;  // assertThat(), assertThatThrownBy(), etc.
+
+@DisplayName("CredentialService 로그인 테스트")
+@ExtendWith(MockitoExtension.class)
+class CredentialServiceLoginTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private CredentialService credentialService;
+
+    @Test
+    @DisplayName("로그인 성공 시 User를 반환한다")
+    void shouldLoginSuccessfully() {
+        // given
+        LoginRequest request = new LoginRequest("testuser", "correctPassword");
+        User mockUser = User.createUser("testuser", "encodedPassword", "홍길동", "010-1234-5678");
+
+        given(userRepository.findByUsername("testuser")).willReturn(Optional.of(mockUser));
+        given(passwordEncoder.matches("correctPassword", "encodedPassword")).willReturn(true);
+
+        // when
+        User loggedInUser = credentialService.login(request);
+
+        // then
+        assertThat(loggedInUser).isEqualTo(mockUser);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자로 로그인 시 LoginFailedException을 던진다")
+    void shouldFailLoginWhenUserNotFound() {
+        // given
+        LoginRequest request = new LoginRequest("nonexistent", "password");
+
+        given(userRepository.findByUsername("nonexistent")).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> credentialService.login(request))
+                .isInstanceOf(LoginFailedException.class);
+    }
+
+    @Test
+    @DisplayName("비밀번호가 일치하지 않으면 LoginFailedException을 던진다")
+    void shouldFailLoginWhenPasswordIncorrect() {
+        // given
+        LoginRequest request = new LoginRequest("testuser", "wrongPassword");
+        User mockUser = User.createUser("testuser", "encodedPassword", "홍길동", "010-1234-5678");
+
+        given(userRepository.findByUsername("testuser")).willReturn(Optional.of(mockUser));
+        given(passwordEncoder.matches("wrongPassword", "encodedPassword")).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> credentialService.login(request))
+                .isInstanceOf(LoginFailedException.class);
+    }
+}

--- a/src/test/java/org/example/hugmeexp/global/auth/service/CredentialService/CredentialServiceRegisterTest.java
+++ b/src/test/java/org/example/hugmeexp/global/auth/service/CredentialService/CredentialServiceRegisterTest.java
@@ -1,0 +1,84 @@
+package org.example.hugmeexp.global.auth.service.CredentialService;
+
+import org.example.hugmeexp.domain.user.entity.User;
+import org.example.hugmeexp.domain.user.exception.PhoneNumberDuplicatedException;
+import org.example.hugmeexp.domain.user.exception.UsernameDuplicatedException;
+import org.example.hugmeexp.domain.user.repository.UserRepository;
+import org.example.hugmeexp.global.infra.auth.dto.request.RegisterRequest;
+import org.example.hugmeexp.global.infra.auth.service.CredentialService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.mockito.Mockito.*;           // when(), verify(), any(), eq(), etc.
+import static org.mockito.BDDMockito.*;        // given(), willReturn(), willThrow(), etc.
+import static org.assertj.core.api.Assertions.*;  // assertThat(), assertThatThrownBy(), etc.
+
+@DisplayName("CredentialService 회원가입 테스트")
+@ExtendWith(MockitoExtension.class)
+class CredentialServiceRegisterTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private CredentialService credentialService;
+
+    @Test
+    @DisplayName("회원가입 성공 시 유저가 저장되고 암호화된 비밀번호를 가진다")
+    void shouldRegisterUserSuccessfully() {
+        // given
+        RegisterRequest request = new RegisterRequest(
+                "testuser", "rawPassword123!", "홍길동", "010-1234-5678"
+        );
+
+        given(userRepository.existsByUsername("testuser")).willReturn(false);
+        given(userRepository.existsByPhoneNumber("010-1234-5678")).willReturn(false);
+        given(passwordEncoder.encode("rawPassword123!")).willReturn("encodedPassword123!");
+        given(userRepository.save(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        User savedUser = credentialService.registerNewUser(request);
+
+        // then
+        assertThat(savedUser.getUsername()).isEqualTo("testuser");
+        assertThat(savedUser.getName()).isEqualTo("홍길동");
+        assertThat(savedUser.getPhoneNumber()).isEqualTo("010-1234-5678");
+        assertThat(savedUser.getPassword()).isEqualTo("encodedPassword123!");
+
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("중복된 사용자명이 존재하면 UsernameDuplicatedException을 던진다")
+    void shouldFailRegistrationWhenUsernameIsDuplicated() {
+        // given
+        RegisterRequest request = new RegisterRequest("dupUser", "pw123!", "name", "010-0000-0000");
+        given(userRepository.existsByUsername("dupUser")).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> credentialService.registerNewUser(request))
+                .isInstanceOf(UsernameDuplicatedException.class);
+    }
+
+    @Test
+    @DisplayName("중복된 전화번호가 존재하면 PhoneNumberDuplicatedException을 던진다")
+    void shouldFailRegistrationWhenPhoneNumberIsDuplicated() {
+        // given
+        RegisterRequest request = new RegisterRequest("newuser", "pw123!", "name", "010-0000-0000");
+        given(userRepository.existsByUsername("newuser")).willReturn(false);
+        given(userRepository.existsByPhoneNumber("010-0000-0000")).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> credentialService.registerNewUser(request))
+                .isInstanceOf(PhoneNumberDuplicatedException.class);
+    }
+}
+

--- a/src/test/java/org/example/hugmeexp/global/auth/service/TokenServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/global/auth/service/TokenServiceTest.java
@@ -1,0 +1,122 @@
+package org.example.hugmeexp.global.auth.service;
+
+import org.example.hugmeexp.domain.user.enums.UserRole;
+import org.example.hugmeexp.global.infra.auth.dto.response.AuthResponse;
+import org.example.hugmeexp.global.infra.auth.exception.InvalidRefreshTokenException;
+import org.example.hugmeexp.global.infra.auth.exception.TokenReuseDetectedException;
+import org.example.hugmeexp.global.infra.auth.jwt.JwtTokenProvider;
+import org.example.hugmeexp.global.infra.auth.service.RedisSessionService;
+import org.example.hugmeexp.global.infra.auth.service.TokenService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+
+import static org.mockito.Mockito.*;           // when(), verify(), any(), eq(), etc.
+import static org.mockito.BDDMockito.*;        // given(), willReturn(), willThrow(), etc.
+import static org.assertj.core.api.Assertions.*;  // assertThat(), assertThatThrownBy(), etc.
+
+@DisplayName("TokenServiceTest")
+@ExtendWith(MockitoExtension.class)
+class TokenServiceTest {
+
+    @Mock private RedisSessionService redisSessionService;
+    @Mock private StringRedisTemplate redisTemplate;
+    @Mock private JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks private TokenService tokenService;
+
+    @Test
+    @DisplayName("유효한 리프레시 토큰이 주어지면 기존 토큰을 무효화하고 새 토큰을 발급 및 저장한다")
+    void reissueNewTokens_givenValidRefreshToken() {
+        // given
+        String accessToken = "access.token";
+        String refreshToken = "refresh.token";
+        String username = "user123";
+        String role = "ROLE_USER";
+        String newAccessToken = "new.access.token";
+        String newRefreshToken = "new.refresh.token";
+
+        willDoNothing().given(jwtTokenProvider).validateAccessTokenForReissue(accessToken);
+        given(jwtTokenProvider.validate(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.isRefreshTokenRevoked(refreshToken)).willReturn(false);
+        given(jwtTokenProvider.getUsername(refreshToken)).willReturn(username);
+        given(jwtTokenProvider.getRole(refreshToken)).willReturn(role);
+        willDoNothing().given(jwtTokenProvider).revokeRefreshToken(refreshToken);
+        given(jwtTokenProvider.createAccessToken(username, role)).willReturn(newAccessToken);
+        given(jwtTokenProvider.createRefreshToken(eq(username), any(UserRole.class))).willReturn(newRefreshToken);
+        given(jwtTokenProvider.getTokenRemainingTimeMillis(newRefreshToken)).willReturn(3600000L);
+
+        ValueOperations<String, String> valueOps = mock(ValueOperations.class);
+        given(redisTemplate.opsForValue()).willReturn(valueOps);
+
+        // when
+        AuthResponse result = tokenService.refreshTokens(accessToken, refreshToken);
+
+        // then
+        assertThat(result.getAccessToken()).isEqualTo(newAccessToken);
+        assertThat(result.getRefreshToken()).isEqualTo(newRefreshToken);
+
+        verify(valueOps).set(eq("refresh:" + username), eq(newRefreshToken), eq(Duration.ofMillis(3600000L)));
+    }
+
+    @Test
+    @DisplayName("재사용된 리프레시 토큰이면 예외를 발생시키고 기존 리프레시 토큰을 삭제한다")
+    void shouldThrow_whenRefreshTokenAlreadyUsed() {
+        // given
+        String accessToken = "access.token";
+        String refreshToken = "used.refresh.token";
+        String username = "user123";
+
+        willDoNothing().given(jwtTokenProvider).validateAccessTokenForReissue(accessToken);
+        given(jwtTokenProvider.validate(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.isRefreshTokenRevoked(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.getUsername(refreshToken)).willReturn(username);
+
+        // when & then
+        assertThatThrownBy(() -> tokenService.refreshTokens(accessToken, refreshToken))
+                .isInstanceOf(TokenReuseDetectedException.class);
+
+        verify(redisTemplate).delete("refresh:" + username);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 리프레시 토큰이면 예외가 발생한다")
+    void shouldThrow_whenRefreshTokenInvalid() {
+        // given
+        String accessToken = "access.token";
+        String refreshToken = "invalid.token";
+
+        willDoNothing().given(jwtTokenProvider).validateAccessTokenForReissue(accessToken);
+        given(jwtTokenProvider.validate(refreshToken)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> tokenService.refreshTokens(accessToken, refreshToken))
+                .isInstanceOf(InvalidRefreshTokenException.class);
+    }
+
+    @Test
+    @DisplayName("로그아웃 시 refresh 토큰을 삭제하고 access 토큰을 블랙리스트에 추가한다")
+    void shouldLogoutAndBlacklistAccessToken() {
+        // given
+        String accessToken = "logout.token";
+        String username = "user123";
+        long remainingTime = 300000L;
+
+        given(jwtTokenProvider.getUsername(accessToken)).willReturn(username);
+        given(jwtTokenProvider.getTokenRemainingTimeMillis(accessToken)).willReturn(remainingTime);
+
+        // when
+        tokenService.logout(accessToken);
+
+        // then
+        verify(redisTemplate).delete("refresh:" + username);
+        verify(redisSessionService).blacklistAccessToken(accessToken, remainingTime);
+    }
+}


### PR DESCRIPTION
### 변경 사항
- 회원 권한을 변경할 수 있는 관리자 기능이 추가되었습니다.
- 회원 상세 정보를 조회할 수 있는 컨트롤러가 추가되었습니다.
- 회원 프로필 이미지 관련 응답이 `profileImage` 또는  `profileImagePath`로 일관성이 없었는데 `profileImage`로 모두 통일되었습니다.
- 인증/인가 관련 테스트 코드가 추가되었습니다. #20

이로써 현재까지 회원 관련 기능은 아래와 같습니다.
<img width="893" alt="image" src="https://github.com/user-attachments/assets/6fc09ede-d885-41ee-82e6-38a5d7310f6d" />

Closes #20


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 사용자 정보 조회 및 사용자 역할 변경을 위한 새로운 REST API 엔드포인트가 추가되었습니다.
    - 사용자 역할 변경 요청을 위한 DTO가 도입되었습니다.

- **버그 수정**
    - 사용자 프로필 이미지 응답 필드명이 일관성 있게 변경되었습니다.

- **리팩터링**
    - DTO 클래스들의 생성자 및 빌더 패턴 적용으로 객체 생성 방식이 개선되었습니다.
    - 일부 메서드 반환 타입 및 명명 방식이 명확하게 변경되었습니다.

- **테스트**
    - 로그아웃, 토큰 갱신, 회원가입, 인증 서비스 등 인증 관련 통합 및 단위 테스트가 대폭 추가되었습니다.
    - 테스트에서 토큰 만료 시간이 짧게 조정되어 테스트 효율성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->