### PR TITLE
칭찬 게시물 세부 조회 기능

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/praise/controller/PraiseController.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/controller/PraiseController.java
@@ -173,22 +173,22 @@ public class PraiseController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-//    /* 칭찬 상세 조회 */
-//    @Operation(summary = "칭찬 상세 조회", description = "칭찬 게시물 한 개를 조회합니다.")
-//    @GetMapping("/{praiseId}")
-//    public ResponseEntity<Response<PraiseDetailResponseDTO>> getPraiseDetail(
-//            @PathVariable Long praiseId
-//    ){
-//        log.info("Received request for praise detail: praiseId={}",praiseId);
-//
-//        PraiseDetailResponseDTO praiseDetail = praiseService.getPraiseDetail(praiseId);
-//
-//        Response<PraiseDetailResponseDTO> response = Response.<PraiseDetailResponseDTO>builder()
-//                .message("조회 완료")
-//                .data(praiseDetail)
-//                .build();
-//
-//        return ResponseEntity.status(HttpStatus.OK).body(response);
-//    }
+    /* 칭찬 상세 조회 */
+    @Operation(summary = "칭찬 상세 조회", description = "칭찬 게시물 한 개를 조회합니다.")
+    @GetMapping("/{praiseId}")
+    public ResponseEntity<Response<PraiseDetailResponseDTO>> getPraiseDetail(
+            @PathVariable Long praiseId
+    ){
+        log.info("Received request for praise detail: praiseId={}",praiseId);
+
+        PraiseDetailResponseDTO praiseDetail = praiseService.getPraiseDetail(praiseId);
+
+        Response<PraiseDetailResponseDTO> response = Response.<PraiseDetailResponseDTO>builder()
+                .message("조회 완료")
+                .data(praiseDetail)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
 
 }

--- a/src/main/java/org/example/hugmeexp/domain/praise/dto/CommentResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/dto/CommentResponseDTO.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.example.hugmeexp.domain.praise.entity.PraiseComment;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Getter
 @AllArgsConstructor
@@ -17,13 +18,15 @@ public class CommentResponseDTO {
     private Long id;    // PK
     private String commenterName;    // 댓글 작성자 이름
     private String content;    // 댓글 내용
+    private Map<String, Integer> emojiReactions;    // 이모지별 반응 수
     private LocalDateTime createdAt;    // 작성 시간
 
-    public static CommentResponseDTO from(PraiseComment comment){
+    public static CommentResponseDTO from(PraiseComment comment, Map<String, Integer> emojiReactions){
         return CommentResponseDTO.builder()
                 .id(comment.getId())
                 .commenterName(comment.getCommentWriter().getName())
                 .content(comment.getContent())
+                .emojiReactions(emojiReactions)
                 .createdAt(comment.getCreatedAt())
                 .build();
     }

--- a/src/main/java/org/example/hugmeexp/domain/praise/dto/CommentResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/dto/CommentResponseDTO.java
@@ -1,0 +1,30 @@
+package org.example.hugmeexp.domain.praise.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.hugmeexp.domain.praise.entity.PraiseComment;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CommentResponseDTO {
+
+    private Long id;    // PK
+    private String commenterName;    // 댓글 작성자 이름
+    private String content;    // 댓글 내용
+    private LocalDateTime createdAt;    // 작성 시간
+
+    public static CommentResponseDTO from(PraiseComment comment){
+        return CommentResponseDTO.builder()
+                .id(comment.getId())
+                .commenterName(comment.getCommentWriter().getName())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/praise/dto/PraiseDetailResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/dto/PraiseDetailResponseDTO.java
@@ -13,7 +13,6 @@ import org.example.hugmeexp.domain.user.entity.User;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
@@ -32,11 +31,17 @@ public class PraiseDetailResponseDTO {
     private List<CommentResponseDTO> comments;     // 댓글 리스트
 //    private String profileImageUrl;
 
-    public static PraiseDetailResponseDTO from(Praise praise, List<PraiseReceiver> receivers, List<PraiseComment> commentList, Map<String, Integer> emojiReactions){
+    public static PraiseDetailResponseDTO from(Praise praise, List<PraiseReceiver> receivers, List<PraiseComment> commentList, Map<String, Integer> emojiReactions, Map<Long, Map<String,Integer>> commentEmojiMap){
 
         List<String> receiverNames = receivers.stream()
                 .map(praiseReceiver -> praiseReceiver.getReceiver().getName())
                 .toList();
+
+        List<CommentResponseDTO> commentResponse = commentList.stream()
+                .map(comment -> {Map<String,Integer> emojis = commentEmojiMap.getOrDefault(comment.getId(),Map.of());
+            return CommentResponseDTO.from(comment, emojis);
+        }).toList();
+
 
         return PraiseDetailResponseDTO.builder()
                 .id(praise.getId())
@@ -47,7 +52,7 @@ public class PraiseDetailResponseDTO {
                 .createdAt(praise.getCreatedAt())
                 .emojiReactions(emojiReactions)
                 .commentCount(commentList.size())
-                .comments(commentList.stream().map(CommentResponseDTO::from).collect(Collectors.toList()))
+                .comments(commentResponse)
                 .build();
     }
 }

--- a/src/main/java/org/example/hugmeexp/domain/praise/dto/PraiseDetailResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/dto/PraiseDetailResponseDTO.java
@@ -22,7 +22,7 @@ public class PraiseDetailResponseDTO {
 
     private Long id;    // 칭찬 ID
     private String senderName;    // 칭찬을 보낸 사람
-    private List<String> receiverName;    // 칭찬을 받은 사람
+    private List<String> receiverNames;    // 칭찬을 받은 사람
     private String content;    // 칭찬 내용
     private PraiseType type;    // 칭찬 타입
     private LocalDateTime createdAt;    // 칭찬을 작성한 시간
@@ -46,7 +46,7 @@ public class PraiseDetailResponseDTO {
         return PraiseDetailResponseDTO.builder()
                 .id(praise.getId())
                 .senderName(praise.getSender().getName())
-                .receiverName(receiverNames)
+                .receiverNames(receiverNames)
                 .content(praise.getContent())
                 .type(praise.getPraiseType())
                 .createdAt(praise.getCreatedAt())

--- a/src/main/java/org/example/hugmeexp/domain/praise/dto/PraiseDetailResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/dto/PraiseDetailResponseDTO.java
@@ -1,0 +1,53 @@
+package org.example.hugmeexp.domain.praise.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.hugmeexp.domain.praise.entity.Praise;
+import org.example.hugmeexp.domain.praise.entity.PraiseComment;
+import org.example.hugmeexp.domain.praise.entity.PraiseReceiver;
+import org.example.hugmeexp.domain.praise.enums.PraiseType;
+import org.example.hugmeexp.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PraiseDetailResponseDTO {
+
+    private Long id;    // 칭찬 ID
+    private String senderName;    // 칭찬을 보낸 사람
+    private List<String> receiverName;    // 칭찬을 받은 사람
+    private String content;    // 칭찬 내용
+    private PraiseType type;    // 칭찬 타입
+    private LocalDateTime createdAt;    // 칭찬을 작성한 시간
+    private Map<String, Integer> emojiReactions;    // 이모지별 반응 수
+    private int commentCount;    // 댓글 수
+    private List<CommentResponseDTO> comments;     // 댓글 리스트
+//    private String profileImageUrl;
+
+    public static PraiseDetailResponseDTO from(Praise praise, List<PraiseReceiver> receivers, List<PraiseComment> commentList, Map<String, Integer> emojiReactions){
+
+        List<String> receiverNames = receivers.stream()
+                .map(praiseReceiver -> praiseReceiver.getReceiver().getName())
+                .toList();
+
+        return PraiseDetailResponseDTO.builder()
+                .id(praise.getId())
+                .senderName(praise.getSender().getName())
+                .receiverName(receiverNames)
+                .content(praise.getContent())
+                .type(praise.getPraiseType())
+                .createdAt(praise.getCreatedAt())
+                .emojiReactions(emojiReactions)
+                .commentCount(commentList.size())
+                .comments(commentList.stream().map(CommentResponseDTO::from).collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/praise/entity/CommentEmojiReaction.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/entity/CommentEmojiReaction.java
@@ -21,11 +21,11 @@ public class CommentEmojiReaction extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id", nullable = false)
-    private PraiseComment commentId;    // 댓글에 반응하기
+    private PraiseComment comment;    // 댓글에 반응하기
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reaction_writer_id", nullable = false)
-    private User reactorWriterId;    // 반응한 사람 이름
+    private User reactorWriter;    // 반응한 사람 이름
 
     @Column(nullable = false, length = 1)
     private String emoji;    // 이모지 값

--- a/src/main/java/org/example/hugmeexp/domain/praise/exception/PraiseNotFoundException.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/exception/PraiseNotFoundException.java
@@ -1,0 +1,11 @@
+package org.example.hugmeexp.domain.praise.exception;
+
+import org.example.hugmeexp.global.common.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+public class PraiseNotFoundException extends BaseCustomException {
+
+    public PraiseNotFoundException() {
+        super(HttpStatus.NOT_FOUND,"칭찬 게시물을 찾을 수 없습니다",404);
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/praise/repository/CommentEmojiReactionRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/repository/CommentEmojiReactionRepository.java
@@ -13,6 +13,6 @@ public interface CommentEmojiReactionRepository extends JpaRepository<CommentEmo
 
     /* 댓글에 달린 이모지를 종류별로 그룹핑하여 개수 반환 */
     @Query("SELECT r.emoji, COUNT(r) FROM CommentEmojiReaction r " +
-            "WHERE r.commentId = :comment GROUP BY r.emoji")
+            "WHERE r.comment = :comment GROUP BY r.emoji")
     List<Object[]> countGroupedByEmoji(PraiseComment comment);
 }

--- a/src/main/java/org/example/hugmeexp/domain/praise/repository/CommentEmojiReactionRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/repository/CommentEmojiReactionRepository.java
@@ -1,9 +1,18 @@
 package org.example.hugmeexp.domain.praise.repository;
 
 import org.example.hugmeexp.domain.praise.entity.CommentEmojiReaction;
+import org.example.hugmeexp.domain.praise.entity.PraiseComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface CommentEmojiReactionRepository extends JpaRepository<CommentEmojiReaction, Long> {
+
+    /* 댓글에 달린 이모지를 종류별로 그룹핑하여 개수 반환 */
+    @Query("SELECT r.emoji, COUNT(r) FROM CommentEmojiReaction r " +
+            "WHERE r.commentId = :comment GROUP BY r.emoji")
+    List<Object[]> countGroupedByEmoji(PraiseComment comment);
 }

--- a/src/main/java/org/example/hugmeexp/domain/praise/repository/CommentRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/repository/CommentRepository.java
@@ -5,7 +5,14 @@ import org.example.hugmeexp.domain.praise.entity.PraiseComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CommentRepository extends JpaRepository<PraiseComment, Long> {
+
+    /* 해당 칭찬에 달린 댓글 수 조회 */
     long countByPraise(Praise praise);
+
+    /* 해당 칭찬에 달린 댓글 전체 목록 조회 */
+    List<PraiseComment> findByPraise(Praise praise);
 }

--- a/src/main/java/org/example/hugmeexp/domain/praise/repository/PraiseEmojiReactionRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/repository/PraiseEmojiReactionRepository.java
@@ -17,6 +17,7 @@ public interface PraiseEmojiReactionRepository extends JpaRepository<PraiseEmoji
 //    @Query("SELECT r.emoji, COUNT(r) FROM PraiseEmojiReaction r WHERE r.praise = :praise GROUP BY r.emoji")
 //    Map<String, Integer> countGroupedMapByPraise(Praise praise);
 
+    /* 특정 칭찬에 대한 이모지별 반응 수 조회 (이모지, 개수 순으로 반환) */
     @Query("SELECT r.emoji, COUNT(r) FROM PraiseEmojiReaction r " +
             "WHERE r.praise = :praise GROUP BY r.emoji")
     List<Object[]> countGroupedByEmoji(@Param("praise") Praise praise);

--- a/src/main/java/org/example/hugmeexp/domain/praise/repository/PraiseReceiverRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/repository/PraiseReceiverRepository.java
@@ -42,4 +42,7 @@ public interface PraiseReceiverRepository extends JpaRepository<PraiseReceiver, 
             "   GROUP BY pr2.praise.sender.id) " +
             "ORDER BY pr.praise.createdAt DESC")
     List<Praise> findLatestPraisePerSender(Long userId);
+
+    /* 칭찬 상세 조회에 대한 칭찬 받은 사람 리스트 조회 */
+    List<PraiseReceiver> findByPraise(Praise praise);
 }

--- a/src/main/java/org/example/hugmeexp/domain/praise/service/PraiseService.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/service/PraiseService.java
@@ -2,13 +2,12 @@ package org.example.hugmeexp.domain.praise.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.hugmeexp.domain.praise.dto.PraiseRatioResponseDTO;
-import org.example.hugmeexp.domain.praise.dto.PraiseRequestDTO;
-import org.example.hugmeexp.domain.praise.dto.PraiseResponseDTO;
-import org.example.hugmeexp.domain.praise.dto.RecentPraiseSenderResponseDTO;
+import org.example.hugmeexp.domain.praise.dto.*;
 import org.example.hugmeexp.domain.praise.entity.Praise;
+import org.example.hugmeexp.domain.praise.entity.PraiseComment;
 import org.example.hugmeexp.domain.praise.entity.PraiseReceiver;
 import org.example.hugmeexp.domain.praise.enums.PraiseType;
+import org.example.hugmeexp.domain.praise.exception.PraiseNotFoundException;
 import org.example.hugmeexp.domain.praise.exception.UserNotFoundInPraiseException;
 import org.example.hugmeexp.domain.praise.mapper.PraiseMapper;
 import org.example.hugmeexp.domain.praise.repository.CommentRepository;
@@ -269,5 +268,28 @@ public class PraiseService {
                 .limit(3)
                 .map(RecentPraiseSenderResponseDTO::from)
                 .collect(Collectors.toList());
+    }
+
+    /* 칭찬 상세 조회 */
+    public PraiseDetailResponseDTO getPraiseDetail(Long praiseId) {
+
+        // 칭찬 엔티티 조회
+        Praise praise = praiseRepository.findById(praiseId).orElseThrow(() -> new PraiseNotFoundException());
+
+        // 칭찬 받은 사람 리스트 조회
+        List<PraiseReceiver> receiverList = praiseReceiverRepository.findByPraise(praise);
+
+        // 댓글 목록 조회
+        List<PraiseComment> commentList = commentRepository.findByPraise(praise);
+
+        // 이모지 반응 수 조회
+        List<Object[]> counts = praiseEmojiReactionRepository.countGroupedByEmoji(praise);
+        Map<String, Integer> emojiCount = counts.stream()
+                .collect(Collectors.toMap(
+                        row -> (String) row[0],
+                        row -> ((Long) row[1]).intValue()
+                ));
+
+        return PraiseDetailResponseDTO.from(praise,receiverList,commentList,emojiCount);
     }
 }


### PR DESCRIPTION
close #81 
Commit
- 칭찬 게시물 세부 조회 기능
![스크린샷 2025-06-23 165045](https://github.com/user-attachments/assets/16e1b055-3f5f-488e-b19e-4c44d0edab44)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 특정 칭찬 게시물의 상세 정보를 조회할 수 있는 API가 추가되었습니다. 이제 게시물의 작성자, 수신자 목록, 내용, 타입, 생성일, 이모지 반응 수, 댓글 수, 댓글 목록을 한 번에 확인할 수 있습니다.
  - 댓글의 이모지 반응 수를 포함한 상세 정보가 제공됩니다.
- **버그 수정**
  - 칭찬 게시물이 존재하지 않을 경우, 적절한 안내 메시지와 함께 404 오류가 반환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->