### PR TITLE
Feature/#74 미션 제출 및 피드백 기능 구현

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/mission/controller/ChallengeController.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/controller/ChallengeController.java
@@ -18,7 +18,7 @@ public class ChallengeController {
     private final MissionService missionService;
 
     @PatchMapping("/{challengeId}")
-    public ResponseEntity<Response<?>> updateChallengeState(@PathVariable Long challengeId, @Valid @RequestParam UserMissionState newProgress) {
+    public ResponseEntity<Response<?>> updateChallengeState(@PathVariable Long challengeId, @RequestParam UserMissionState newProgress) {
         missionService.changeUserMissionState(challengeId, newProgress);
         return ResponseEntity.ok(Response.builder()
                 .message("챌린지 상태가 성공적으로 업데이트되었습니다.")

--- a/src/main/java/org/example/hugmeexp/domain/mission/controller/ChallengeController.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/controller/ChallengeController.java
@@ -1,11 +1,15 @@
 package org.example.hugmeexp.domain.mission.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.example.hugmeexp.domain.mission.dto.request.SubmissionUploadRequest;
 import org.example.hugmeexp.domain.mission.enums.UserMissionState;
 import org.example.hugmeexp.domain.mission.service.MissionService;
 import org.example.hugmeexp.global.common.response.Response;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/challenges")
@@ -14,10 +18,21 @@ public class ChallengeController {
     private final MissionService missionService;
 
     @PatchMapping("/{challengeId}")
-    public ResponseEntity<Response<?>> updateChallengeState(@PathVariable Long challengeId, @RequestParam UserMissionState newProgress) {
+    public ResponseEntity<Response<?>> updateChallengeState(@PathVariable Long challengeId, @Valid @RequestParam UserMissionState newProgress) {
         missionService.changeUserMissionState(challengeId, newProgress);
         return ResponseEntity.ok(Response.builder()
                 .message("챌린지 상태가 성공적으로 업데이트되었습니다.")
                 .build());
     }
+
+    @PostMapping("/{challengeId}/submissions")
+    public ResponseEntity<Response<?>> submitChallenge(@PathVariable Long challengeId,
+                                                       @Valid @ModelAttribute SubmissionUploadRequest submissionUploadRequest,
+                                                       @RequestParam("file") MultipartFile file) {
+        missionService.submitChallenge(challengeId, submissionUploadRequest, file);
+        return ResponseEntity.status(HttpStatus.CREATED).body(Response.builder()
+                .message("챌린지 제출이 성공적으로 완료되었습니다.")
+                .build());
+    }
+
 }

--- a/src/main/java/org/example/hugmeexp/domain/mission/controller/MissionController.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/controller/MissionController.java
@@ -1,7 +1,6 @@
 package org.example.hugmeexp.domain.mission.controller;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.example.hugmeexp.domain.mission.dto.request.MissionRequest;
 import org.example.hugmeexp.domain.mission.service.MissionService;

--- a/src/main/java/org/example/hugmeexp/domain/mission/controller/MissionController.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/controller/MissionController.java
@@ -1,6 +1,7 @@
 package org.example.hugmeexp.domain.mission.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.example.hugmeexp.domain.mission.dto.request.MissionRequest;
 import org.example.hugmeexp.domain.mission.service.MissionService;

--- a/src/main/java/org/example/hugmeexp/domain/mission/controller/SubmissionController.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/controller/SubmissionController.java
@@ -1,0 +1,98 @@
+package org.example.hugmeexp.domain.mission.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.hugmeexp.domain.mission.dto.request.SubmissionFeedbackRequest;
+import org.example.hugmeexp.domain.mission.dto.response.SubmissionResponse;
+import org.example.hugmeexp.domain.mission.exception.SubMissionInternalException;
+import org.example.hugmeexp.domain.mission.exception.SubmissionNotFoundException;
+import org.example.hugmeexp.domain.mission.service.MissionService;
+import org.example.hugmeexp.global.common.response.Response;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@RestController
+@RequestMapping("/api/v1/submissions")
+@RequiredArgsConstructor
+public class SubmissionController {
+    private final MissionService missionService;
+
+    @Value("${file.submission-upload-dir}")
+    private String uploadDir;
+
+    @GetMapping("/{userMissionId}")
+    public ResponseEntity<Response<?>> getSubmissionByMissionId(@PathVariable Long userMissionId) {
+        SubmissionResponse submissionResponse = missionService.getSubmissionByMissionId(userMissionId);
+        return ResponseEntity.ok(Response.builder()
+                .data(submissionResponse)
+                .message("미션 " + userMissionId + "의 제출 정보를 성공적으로 가져왔습니다.")
+                .build());
+    }
+
+    @GetMapping("/{userMissionId}/file")
+    public ResponseEntity<Resource> getSubmissionFileByMissionId(@PathVariable Long userMissionId) {
+        SubmissionResponse submissionResponse = missionService.getSubmissionByMissionId(userMissionId);
+        if (submissionResponse == null || submissionResponse.getFileName() == null) {
+            throw new SubmissionNotFoundException();
+        }
+
+        // 둘 모두 이미 검증된 파일명이지만 다시 한 번 검증
+        String savedFileName = getSafeFileName(submissionResponse.getFileName());
+        String originalFileName = getSafeFileName(submissionResponse.getOriginalFileName()).replaceAll("[\"'/\\\\]", "_");
+        File file = new File(uploadDir, savedFileName);
+        String contentType = MediaType.APPLICATION_OCTET_STREAM_VALUE;
+
+        Resource resource = new FileSystemResource(file);
+
+        if (!resource.exists() || !resource.isReadable()) {
+            throw new SubmissionNotFoundException("제출 파일을 찾을 수 없습니다.");
+        }
+
+        ContentDisposition contentDisposition = ContentDisposition.builder("attachment")
+                .filename(originalFileName, StandardCharsets.UTF_8)
+                .build();
+
+        try {
+            return ResponseEntity.ok()
+                    .contentType(MediaType.parseMediaType(contentType))
+                    .contentLength(resource.contentLength())
+                    .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString())
+                    .body(resource);
+        } catch (IOException e) {
+            throw new SubmissionNotFoundException("파일 크기를 읽을 수 없습니다.");
+        }
+    }
+
+    @PatchMapping("/{userMissionId}/feedback")
+    public ResponseEntity<Response<?>> updateSubmissionFeedback(@PathVariable Long userMissionId,
+                                                                @Valid @RequestBody SubmissionFeedbackRequest submissionFeedbackRequest) {
+
+        missionService.updateSubmissionFeedback(userMissionId, submissionFeedbackRequest);
+        return ResponseEntity.ok(Response.builder()
+                .message("제출 피드백이 성공적으로 업데이트되었습니다.")
+                .build());
+    }
+
+    private static String getSafeFileName(String fileName) {
+        if (fileName == null || fileName.isEmpty()) {
+            throw new SubMissionInternalException("파일 이름이 비어 있거나 null입니다.");
+        }
+
+        return StringUtils.getFilename(StringUtils.cleanPath(fileName));
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/mission/controller/SubmissionController.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/controller/SubmissionController.java
@@ -15,16 +15,12 @@ import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 @RestController
 @RequestMapping("/api/v1/submissions")

--- a/src/main/java/org/example/hugmeexp/domain/mission/controller/SubmissionController.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/controller/SubmissionController.java
@@ -49,8 +49,17 @@ public class SubmissionController {
 
         // 둘 모두 이미 검증된 파일명이지만 다시 한 번 검증
         String savedFileName = getSafeFileName(submissionResponse.getFileName());
-        String originalFileName = getSafeFileName(submissionResponse.getOriginalFileName()).replaceAll("[\"'/\\\\]", "_");
+        String originalFileName = getSafeFileName(submissionResponse.getOriginalFileName()).replaceAll("[^a-zA-Z0-9가-힣._-]", "_");;
         File file = new File(uploadDir, savedFileName);
+
+        try {
+            if (!file.getCanonicalPath().startsWith(new File(uploadDir).getCanonicalPath())) {
+                throw new SubMissionInternalException("잘못된 파일 경로입니다.");
+            }
+        } catch (IOException e) {
+            throw new SubMissionInternalException("파일 경로를 확인하는 중 오류가 발생했습니다.");
+        }
+
         String contentType = MediaType.APPLICATION_OCTET_STREAM_VALUE;
 
         Resource resource = new FileSystemResource(file);

--- a/src/main/java/org/example/hugmeexp/domain/mission/dto/request/SubmissionFeedbackRequest.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/dto/request/SubmissionFeedbackRequest.java
@@ -1,0 +1,18 @@
+package org.example.hugmeexp.domain.mission.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class SubmissionFeedbackRequest {
+    @NotBlank
+    @Length(min = 1, max = 65535)
+    private String feedback;
+}

--- a/src/main/java/org/example/hugmeexp/domain/mission/dto/request/SubmissionUploadRequest.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/dto/request/SubmissionUploadRequest.java
@@ -1,0 +1,21 @@
+package org.example.hugmeexp.domain.mission.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+import org.hibernate.validator.constraints.Length;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Getter
+@Setter
+public class SubmissionUploadRequest {
+    @NotBlank
+    @Length(min = 1, max = 65535)
+    private String comment;
+
+    @NotBlank
+    @Length(min = 1, max = 255)
+    private String fileName;
+}

--- a/src/main/java/org/example/hugmeexp/domain/mission/dto/request/SubmissionUploadRequest.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/dto/request/SubmissionUploadRequest.java
@@ -8,8 +8,7 @@ import org.hibernate.validator.constraints.Length;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
-@Getter
-@Setter
+// Removed redundant @Getter and @Setter annotations
 public class SubmissionUploadRequest {
     @NotBlank
     @Length(min = 1, max = 65535)

--- a/src/main/java/org/example/hugmeexp/domain/mission/dto/response/SubmissionResponse.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/dto/response/SubmissionResponse.java
@@ -1,0 +1,22 @@
+package org.example.hugmeexp.domain.mission.dto.response;
+
+import lombok.*;
+import org.example.hugmeexp.domain.mission.entity.UserMission;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class SubmissionResponse {
+    private Long id;
+
+    private UserMission userMission;
+
+    private String fileName;
+
+    private String originalFileName;
+
+    private String comment;
+
+    private String feedback;
+}

--- a/src/main/java/org/example/hugmeexp/domain/mission/dto/response/SubmissionResponse.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/dto/response/SubmissionResponse.java
@@ -1,7 +1,6 @@
 package org.example.hugmeexp.domain.mission.dto.response;
 
 import lombok.*;
-import org.example.hugmeexp.domain.mission.entity.UserMission;
 
 @Data
 @NoArgsConstructor
@@ -10,7 +9,7 @@ import org.example.hugmeexp.domain.mission.entity.UserMission;
 public class SubmissionResponse {
     private Long id;
 
-    private UserMission userMission;
+    private UserMissionResponse userMission;
 
     private String fileName;
 

--- a/src/main/java/org/example/hugmeexp/domain/mission/entity/Submission.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/entity/Submission.java
@@ -1,0 +1,36 @@
+package org.example.hugmeexp.domain.mission.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"user_mission_id"})})
+public class Submission {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @Setter
+    @JoinColumn(name = "user_mission_id", nullable = false)
+    private UserMission userMission;
+
+    @Column(nullable = false)
+    @Setter
+    private String fileName;
+
+    @Column(nullable = false)
+    @Setter
+    private String originalFileName;
+
+    @Column(nullable = false, length = 65535)
+    private String comment;
+
+    @Setter
+    @Column(length = 65535)
+    private String feedback;
+}

--- a/src/main/java/org/example/hugmeexp/domain/mission/exception/AlreadyExistsUserMissionSubmissionException.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/exception/AlreadyExistsUserMissionSubmissionException.java
@@ -1,0 +1,10 @@
+package org.example.hugmeexp.domain.mission.exception;
+
+import org.example.hugmeexp.global.common.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+public class AlreadyExistsUserMissionSubmissionException extends BaseCustomException {
+    public AlreadyExistsUserMissionSubmissionException() {
+        super(HttpStatus.CONFLICT, "이미 제출한 미션입니다.");
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/mission/exception/SubMissionInternalException.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/exception/SubMissionInternalException.java
@@ -1,0 +1,10 @@
+package org.example.hugmeexp.domain.mission.exception;
+
+import org.example.hugmeexp.global.common.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+public class SubMissionInternalException extends BaseCustomException {
+    public SubMissionInternalException(String s) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, s);
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/mission/exception/SubMissionInternalException.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/exception/SubMissionInternalException.java
@@ -4,7 +4,11 @@ import org.example.hugmeexp.global.common.exception.BaseCustomException;
 import org.springframework.http.HttpStatus;
 
 public class SubMissionInternalException extends BaseCustomException {
-    public SubMissionInternalException(String s) {
-        super(HttpStatus.INTERNAL_SERVER_ERROR, s);
+    public SubMissionInternalException(String message) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, message);
+    }
+
+    public SubMissionInternalException() {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, "서브미션 처리 중 내부 오류가 발생했습니다.");
     }
 }

--- a/src/main/java/org/example/hugmeexp/domain/mission/exception/SubmissionFileUploadException.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/exception/SubmissionFileUploadException.java
@@ -1,0 +1,14 @@
+package org.example.hugmeexp.domain.mission.exception;
+
+import org.example.hugmeexp.global.common.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+public class SubmissionFileUploadException extends BaseCustomException {
+    public SubmissionFileUploadException() {
+        super(HttpStatus.BAD_REQUEST, "파일 업로드에 실패했습니다. 파일 형식이 올바른지 확인해주세요.");
+    }
+
+    public SubmissionFileUploadException(String s) {
+        super(HttpStatus.BAD_REQUEST, s);
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/mission/exception/SubmissionNotFoundException.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/exception/SubmissionNotFoundException.java
@@ -1,0 +1,13 @@
+package org.example.hugmeexp.domain.mission.exception;
+
+import org.example.hugmeexp.global.common.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+public class SubmissionNotFoundException extends BaseCustomException {
+    public SubmissionNotFoundException(String message) {
+        super(HttpStatus.NOT_FOUND, message);
+    }
+    public SubmissionNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "제출 정보를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/mission/mapper/UserMissionSubmissionMapper.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/mapper/UserMissionSubmissionMapper.java
@@ -6,7 +6,8 @@ import org.example.hugmeexp.domain.mission.entity.Submission;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring",
+uses = {UserMissionMapper.class, MissionMapper.class})
 public interface UserMissionSubmissionMapper {
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "userMission", ignore = true)

--- a/src/main/java/org/example/hugmeexp/domain/mission/mapper/UserMissionSubmissionMapper.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/mapper/UserMissionSubmissionMapper.java
@@ -6,8 +6,7 @@ import org.example.hugmeexp.domain.mission.entity.Submission;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper (componentModel = "spring",
-uses = {UserMissionMapper.class})
+@Mapper(componentModel = "spring")
 public interface UserMissionSubmissionMapper {
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "userMission", ignore = true)

--- a/src/main/java/org/example/hugmeexp/domain/mission/mapper/UserMissionSubmissionMapper.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/mapper/UserMissionSubmissionMapper.java
@@ -1,0 +1,19 @@
+package org.example.hugmeexp.domain.mission.mapper;
+
+import org.example.hugmeexp.domain.mission.dto.request.SubmissionUploadRequest;
+import org.example.hugmeexp.domain.mission.dto.response.SubmissionResponse;
+import org.example.hugmeexp.domain.mission.entity.Submission;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper (componentModel = "spring",
+uses = {UserMissionMapper.class})
+public interface UserMissionSubmissionMapper {
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "userMission", ignore = true)
+    @Mapping(target = "originalFileName", ignore = true)
+    @Mapping(target = "feedback", ignore = true)
+    Submission toEntity(SubmissionUploadRequest submissionUploadRequest);
+
+    SubmissionResponse toSubmissionResponse(Submission submission);
+}

--- a/src/main/java/org/example/hugmeexp/domain/mission/repository/UserMissionSubmissionRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/repository/UserMissionSubmissionRepository.java
@@ -1,0 +1,13 @@
+package org.example.hugmeexp.domain.mission.repository;
+
+import org.example.hugmeexp.domain.mission.entity.UserMission;
+import org.example.hugmeexp.domain.mission.entity.Submission;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserMissionSubmissionRepository extends JpaRepository<Submission, Long> {
+    boolean existsByUserMission(UserMission userMission);
+
+    Optional<Submission> findByUserMission(UserMission userMission);
+}

--- a/src/main/java/org/example/hugmeexp/domain/mission/service/MissionService.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/service/MissionService.java
@@ -1,8 +1,12 @@
 package org.example.hugmeexp.domain.mission.service;
 import org.example.hugmeexp.domain.mission.dto.request.MissionRequest;
+import org.example.hugmeexp.domain.mission.dto.request.SubmissionFeedbackRequest;
+import org.example.hugmeexp.domain.mission.dto.request.SubmissionUploadRequest;
 import org.example.hugmeexp.domain.mission.dto.response.MissionResponse;
+import org.example.hugmeexp.domain.mission.dto.response.SubmissionResponse;
 import org.example.hugmeexp.domain.mission.dto.response.UserMissionResponse;
 import org.example.hugmeexp.domain.mission.enums.UserMissionState;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -24,4 +28,10 @@ public interface MissionService {
     UserMissionResponse challengeMission(String username, Long missionId);
 
     void changeUserMissionState(Long userMissionId, UserMissionState newProgress);
+
+    void submitChallenge(Long userMissionId, SubmissionUploadRequest submissionUploadRequest, MultipartFile file);
+
+    SubmissionResponse getSubmissionByMissionId(Long userMissionId);
+
+    void updateSubmissionFeedback(Long userMissionId, SubmissionFeedbackRequest submissionFeedbackRequest);
 }

--- a/src/main/java/org/example/hugmeexp/domain/mission/service/MissionServiceImpl.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/service/MissionServiceImpl.java
@@ -229,7 +229,7 @@ public class MissionServiceImpl implements MissionService {
 
         String originalFilename = file.getOriginalFilename();
 
-        return new File(originalFilename).getName();
+        return new File(originalFilename).getName().replaceAll("[^a-zA-Z0-9가-힣._-]", "_");
     }
 
     @Override

--- a/src/main/java/org/example/hugmeexp/global/common/exception/ExceptionController.java
+++ b/src/main/java/org/example/hugmeexp/global/common/exception/ExceptionController.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.hugmeexp.global.common.exception.response.ErrorResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -109,6 +111,17 @@ public class ExceptionController {
                 .body(ErrorResponse.builder()
                         .code(500)
                         .message("일시적으로 접속이 원활하지 않습니다.")
+                        .build());
+    }
+
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    public ResponseEntity<?> handleMissingServletRequestPartException(MissingServletRequestPartException ex) {
+        // 예외 메시지에 필요한 내용을 추출하거나 커스텀 메시지로 반환
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.builder()
+                        .code(HttpStatus.BAD_REQUEST.value())
+                        .message("요청 파라미터 값이 올바르지 않습니다.")
                         .build());
     }
 }

--- a/src/main/java/org/example/hugmeexp/global/common/exception/ExceptionController.java
+++ b/src/main/java/org/example/hugmeexp/global/common/exception/ExceptionController.java
@@ -115,7 +115,7 @@ public class ExceptionController {
     }
 
     @ExceptionHandler(MissingServletRequestPartException.class)
-    public ResponseEntity<?> handleMissingServletRequestPartException(MissingServletRequestPartException ex) {
+    public ResponseEntity<?> handleMissingServletRequestPartException(MissingServletRequestPartException ignored) {
         // 예외 메시지에 필요한 내용을 추출하거나 커스텀 메시지로 반환
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)

--- a/src/test/java/org/example/hugmeexp/domain/mission/controller/ChallengeControllerTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/mission/controller/ChallengeControllerTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,12 +20,10 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/src/test/java/org/example/hugmeexp/domain/mission/controller/ChallengeControllerTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/mission/controller/ChallengeControllerTest.java
@@ -1,5 +1,6 @@
 package org.example.hugmeexp.domain.mission.controller;
 
+import org.example.hugmeexp.domain.mission.dto.request.SubmissionUploadRequest;
 import org.example.hugmeexp.domain.mission.enums.UserMissionState;
 import org.example.hugmeexp.domain.mission.service.MissionService;
 import org.example.hugmeexp.global.common.exception.ExceptionController;
@@ -7,21 +8,32 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("챌린지 컨트롤러 테스트")
 class ChallengeControllerTest {
+    private final String BASE_URL = "/api/v1/challenges";
     private MockMvc mockMvc;
 
     @Mock
@@ -45,7 +57,7 @@ class ChallengeControllerTest {
         UserMissionState newState = UserMissionState.COMPLETED;
 
         // when & then
-        mockMvc.perform(patch("/api/v1/challenges/{challengeId}", challengeId)
+        mockMvc.perform(patch(BASE_URL + "/{challengeId}", challengeId)
                         .param("newProgress", newState.name()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message")
@@ -62,8 +74,101 @@ class ChallengeControllerTest {
     void updateChallengeState_BadRequest_InvalidEnum() throws Exception {
         Long challengeId = 123L;
         // invalid enum value
-        mockMvc.perform(patch("/api/v1/challenges/{challengeId}", challengeId)
+        mockMvc.perform(patch(BASE_URL + "/{challengeId}", challengeId)
                         .param("newProgress", "INVALID_STATE"))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("챌린지 제출 성공 테스트")
+    void submitChallenge_Success() throws Exception {
+        // given
+        Long challengeId = 1L;
+        String fileName = "testFileName";
+        String comment = "챌린지 제출합니다";
+
+        // 파일 생성
+        MockMultipartFile file = new MockMultipartFile(
+                "file", // 반드시 @RequestParam("file")의 이름과 일치
+                "test.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                "file-content".getBytes()
+        );
+
+        // doNothing mocking
+        doNothing().when(missionService).submitChallenge(anyLong(), any(SubmissionUploadRequest.class), any(MultipartFile.class));
+
+        // when
+        ResultActions result = mockMvc.perform(
+                multipart(BASE_URL + "/{challengeId}/submissions", challengeId)
+                        .file(file)
+                        .param("fileName", fileName)
+                        .param("comment", comment)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isCreated())
+                .andExpect(jsonPath("$.message").value("챌린지 제출이 성공적으로 완료되었습니다."));
+
+        // Service가 한번 호출되었는지 검증
+        verify(missionService, times(1))
+                .submitChallenge(eq(challengeId), any(SubmissionUploadRequest.class), any(MultipartFile.class));
+    }
+
+    @Test
+    @DisplayName("챌린지 제출 실패 테스트 - 파일 누락")
+    void submitChallenge_Fail_MissingFile() throws Exception {
+        // given
+        Long challengeId = 1L;
+        String comment = "챌린지 인증합니다!";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                multipart(BASE_URL + "/{challengeId}/submissions", challengeId)
+                        .param("comment", comment)
+                        .param("fileName", "testFileName")
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        // @RequestParam("file")은 기본적으로 required=true 이므로 400 Bad Request가 발생해야 함
+        resultActions.andExpect(status().isBadRequest());
+
+        // 서비스 메소드가 호출되지 않았는지 확인
+        verify(missionService, never()).submitChallenge(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("챌린지 제출 실패 테스트 - @Valid 유효성 검사 실패")
+    void submitChallenge_Fail_Validation() throws Exception {
+        // given
+        Long challengeId = 1L;
+        String emptyComment = ""; // @NotBlank 위반
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test-image.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                "test image content".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                multipart(BASE_URL + "/{challengeId}/submissions", challengeId)
+                        .file(file)
+                        .param("comment", emptyComment) // 유효성 검사에 실패할 파라미터
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        // @Valid에 의해 유효성 검사가 실패했으므로 400 Bad Request가 발생해야 함
+        resultActions.andExpect(status().isBadRequest());
+
+        // 서비스 메소드가 호출되지 않았는지 확인
+        verify(missionService, never()).submitChallenge(any(), any(), any());
     }
 }

--- a/src/test/java/org/example/hugmeexp/domain/mission/service/MissionServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/mission/service/MissionServiceTest.java
@@ -1,19 +1,23 @@
 package org.example.hugmeexp.domain.mission.service;
 
 import org.example.hugmeexp.domain.mission.dto.request.MissionRequest;
+import org.example.hugmeexp.domain.mission.dto.request.SubmissionFeedbackRequest;
+import org.example.hugmeexp.domain.mission.dto.request.SubmissionUploadRequest;
 import org.example.hugmeexp.domain.mission.dto.response.MissionResponse;
+import org.example.hugmeexp.domain.mission.dto.response.SubmissionResponse;
 import org.example.hugmeexp.domain.mission.dto.response.UserMissionResponse;
 import org.example.hugmeexp.domain.mission.entity.Mission;
+import org.example.hugmeexp.domain.mission.entity.Submission;
 import org.example.hugmeexp.domain.mission.entity.UserMission;
 import org.example.hugmeexp.domain.mission.enums.Difficulty;
 import org.example.hugmeexp.domain.mission.enums.UserMissionState;
-import org.example.hugmeexp.domain.mission.exception.AlreadyExistsUserMissionException;
-import org.example.hugmeexp.domain.mission.exception.MissionNotFoundException;
-import org.example.hugmeexp.domain.mission.exception.UserMissionNotFoundException;
+import org.example.hugmeexp.domain.mission.exception.*;
 import org.example.hugmeexp.domain.mission.mapper.MissionMapper;
 import org.example.hugmeexp.domain.mission.mapper.UserMissionMapper;
+import org.example.hugmeexp.domain.mission.mapper.UserMissionSubmissionMapper;
 import org.example.hugmeexp.domain.mission.repository.MissionRepository;
 import org.example.hugmeexp.domain.mission.repository.UserMissionRepository;
+import org.example.hugmeexp.domain.mission.repository.UserMissionSubmissionRepository;
 import org.example.hugmeexp.domain.missionGroup.entity.MissionGroup;
 import org.example.hugmeexp.domain.missionGroup.entity.UserMissionGroup;
 import org.example.hugmeexp.domain.missionGroup.exception.MissionGroupNotFoundException;
@@ -26,11 +30,18 @@ import org.example.hugmeexp.domain.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -68,6 +79,15 @@ class MissionServiceTest {
 
     @Mock
     private UserMissionMapper userMissionMapper;
+
+    @Mock
+    private UserMissionSubmissionRepository userMissionSubmissionRepository;
+
+    @Mock
+    private UserMissionSubmissionMapper userMissionSubmissionMapper;
+
+    @TempDir
+    Path tempDir;
 
 
     private final Long SAMPLE_ID = 1L;
@@ -513,5 +533,207 @@ class MissionServiceTest {
         // when & then
         assertThrows(AlreadyExistsUserMissionException.class,
                 () -> missionService.challengeMission(username, missionId));
+    }
+
+
+
+
+
+    @Test
+    @DisplayName("챌린지 제출을 정상적으로 수행한다 - 성공")
+    void submitChallenge_Success() {
+        // Given
+        Long userMissionId = 1L;
+        String originalFileName = "test-image.png";
+        String content = "file content";
+
+        // 서비스의 uploadDir 필드를 임시 디렉토리로 설정
+        // 실제 코드에서는 @Value 등으로 주입되므로, 테스트에서는 ReflectionTestUtils를 사용해 강제로 값을 주입합니다.
+        ReflectionTestUtils.setField(missionService, "uploadDir", tempDir.toString());
+
+        UserMission userMission = UserMission.builder().id(userMissionId).build();
+        SubmissionUploadRequest request = new SubmissionUploadRequest("제출 제목", "제출 내용");
+        MultipartFile file = new MockMultipartFile("file", originalFileName, "image/png", content.getBytes());
+        Submission submission = Submission.builder().build();
+
+        when(userMissionRepository.findById(userMissionId)).thenReturn(Optional.of(userMission));
+        when(userMissionSubmissionRepository.existsByUserMission(userMission)).thenReturn(false);
+        when(userMissionSubmissionMapper.toEntity(request)).thenReturn(submission);
+
+        // When
+        missionService.submitChallenge(userMissionId, request, file);
+
+        // Then
+        // 1. submission이 저장되었는지 검증
+        ArgumentCaptor<Submission> submissionCaptor = ArgumentCaptor.forClass(Submission.class);
+        verify(userMissionSubmissionRepository).save(submissionCaptor.capture());
+
+        // 2. 저장된 submission의 필드들이 올바르게 설정되었는지 검증
+        Submission savedSubmission = submissionCaptor.getValue();
+        assertThat(savedSubmission.getUserMission()).isEqualTo(userMission);
+        assertThat(savedSubmission.getOriginalFileName()).isEqualTo(originalFileName);
+        // UUID는 예측 불가능하므로 null이 아닌지만 확인
+        assertThat(savedSubmission.getFileName()).isNotNull();
+
+        // 3. 실제 파일이 임시 디렉토리에 저장되었는지 검증
+        File savedFile = new File(tempDir.toString(), savedSubmission.getFileName());
+        assertThat(savedFile).exists();
+        assertThat(savedFile).hasContent(content);
+    }
+
+    @Test
+    @DisplayName("이미 제출한 챌린지에 다시 제출하면 예외가 발생한다 - 실패")
+    void submitChallenge_Fail_WhenAlreadyExists() {
+        // Given
+        Long userMissionId = 1L;
+        UserMission userMission = UserMission.builder().id(userMissionId).build();
+        SubmissionUploadRequest request = new SubmissionUploadRequest("제목", "내용");
+        MultipartFile file = new MockMultipartFile("file", "test.txt", "text/plain", "content".getBytes());
+
+        when(userMissionRepository.findById(userMissionId)).thenReturn(Optional.of(userMission));
+        // 이미 제출물이 존재한다고 설정
+        when(userMissionSubmissionRepository.existsByUserMission(userMission)).thenReturn(true);
+
+        // When & Then
+        assertThrows(AlreadyExistsUserMissionSubmissionException.class, () -> {
+            missionService.submitChallenge(userMissionId, request, file);
+        });
+
+        // save 메서드가 호출되지 않았는지 검증
+        verify(userMissionSubmissionRepository, never()).save(any(Submission.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 미션에 챌린지를 제출하면 예외가 발생한다 - 실패")
+    void submitChallenge_Fail_WhenUserMissionNotFound() {
+        // Given
+        Long userMissionId = 999L; // 존재하지 않는 ID
+        SubmissionUploadRequest request = new SubmissionUploadRequest("제목", "내용");
+        MultipartFile file = new MockMultipartFile("file", "test.txt", "text/plain", "content".getBytes());
+
+        when(userMissionRepository.findById(userMissionId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(UserMissionNotFoundException.class, () -> {
+            missionService.submitChallenge(userMissionId, request, file);
+        });
+    }
+
+    @Test
+    @DisplayName("파일 저장 중 IOException 발생 시 SubmissionFileUploadException으로 전환되어 던져진다 - 실패")
+    void submitChallenge_Fail_WhenIoExceptionOccurs() throws IOException {
+        // Given
+        Long userMissionId = 1L;
+        UserMission userMission = UserMission.builder().id(userMissionId).build();
+        SubmissionUploadRequest request = new SubmissionUploadRequest("제목", "내용");
+        Submission submission = Submission.builder().build();
+
+        // transferTo() 메서드에서 IOException을 던지도록 조작된 Mock MultipartFile
+        MultipartFile mockFile = mock(MultipartFile.class);
+        when(mockFile.getOriginalFilename()).thenReturn("valid.name.txt");
+        doThrow(new IOException("Disk is full")).when(mockFile).transferTo(any(File.class));
+
+        ReflectionTestUtils.setField(missionService, "uploadDir", "/invalid/path");
+
+        when(userMissionRepository.findById(userMissionId)).thenReturn(Optional.of(userMission));
+        when(userMissionSubmissionRepository.existsByUserMission(userMission)).thenReturn(false);
+        when(userMissionSubmissionMapper.toEntity(request)).thenReturn(submission);
+
+        // When & Then
+        // RuntimeException인 SubmissionFileUploadException이 발생하는지 확인
+        assertThrows(SubmissionFileUploadException.class, () -> {
+            missionService.submitChallenge(userMissionId, request, mockFile);
+        });
+
+        // @Transactional에 의해 롤백되므로 save는 호출되지만 커밋되지 않음.
+        // 테스트에서는 save가 호출되었는지 여부만 확인할 수 있음.
+        verify(userMissionSubmissionRepository).save(any(Submission.class));
+    }
+
+
+    @Test
+    @DisplayName("사용자 미션 ID로 제출물을 정상적으로 조회한다 - 성공")
+    void getSubmissionByMissionId_Success() {
+        // Given
+        Long userMissionId = 1L;
+        UserMission userMission = UserMission.builder().id(userMissionId).build();
+        Submission submission = Submission.builder().id(10L).comment("제출물").build();
+        SubmissionResponse expectedResponse = SubmissionResponse.builder().id(10L).comment("제출물").build();
+
+        when(userMissionRepository.findById(userMissionId)).thenReturn(Optional.of(userMission));
+        when(userMissionSubmissionRepository.findByUserMission(userMission)).thenReturn(Optional.of(submission));
+        when(userMissionSubmissionMapper.toSubmissionResponse(submission)).thenReturn(expectedResponse);
+
+        // When
+        SubmissionResponse actualResponse = missionService.getSubmissionByMissionId(userMissionId);
+
+        // Then
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+    }
+
+    @Test
+    @DisplayName("제출물이 없는 사용자 미션 ID로 조회 시 예외가 발생한다 - 실패")
+    void getSubmissionByMissionId_Fail_WhenSubmissionNotFound() {
+        // Given
+        Long userMissionId = 1L;
+        UserMission userMission = UserMission.builder().id(userMissionId).build();
+
+        when(userMissionRepository.findById(userMissionId)).thenReturn(Optional.of(userMission));
+        // 제출물이 없다고 설정
+        when(userMissionSubmissionRepository.findByUserMission(userMission)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(SubmissionNotFoundException.class, () -> {
+            missionService.getSubmissionByMissionId(userMissionId);
+        });
+    }
+
+    @Test
+    @DisplayName("제출물에 피드백을 정상적으로 업데이트한다 - 성공")
+    void updateSubmissionFeedback_Success() {
+        // Given
+        Long userMissionId = 1L;
+        String feedbackContent = "피드백 내용입니다.";
+        SubmissionFeedbackRequest request = new SubmissionFeedbackRequest(feedbackContent);
+
+        UserMission userMission = UserMission.builder().id(userMissionId).build();
+        Submission submission = Submission.builder().id(10L).feedback("기존 피드백").build();
+
+        when(userMissionRepository.findById(userMissionId)).thenReturn(Optional.of(userMission));
+        when(userMissionSubmissionRepository.findByUserMission(userMission)).thenReturn(Optional.of(submission));
+
+        // When
+        missionService.updateSubmissionFeedback(userMissionId, request);
+
+        // Then
+        // save 메서드로 전달된 submission 객체를 캡처
+        ArgumentCaptor<Submission> submissionCaptor = ArgumentCaptor.forClass(Submission.class);
+        verify(userMissionSubmissionRepository).save(submissionCaptor.capture());
+
+        // 캡처된 submission 객체의 feedback 필드가 요청된 내용으로 변경되었는지 확인
+        Submission savedSubmission = submissionCaptor.getValue();
+        assertThat(savedSubmission.getFeedback()).isEqualTo(feedbackContent);
+    }
+
+    @Test
+    @DisplayName("제출물이 없는 미션에 피드백 업데이트 시 예외가 발생한다 - 실패")
+    void updateSubmissionFeedback_Fail_WhenSubmissionNotFound() {
+        // Given
+        Long userMissionId = 1L;
+        String feedbackContent = "피드백";
+        SubmissionFeedbackRequest request = new SubmissionFeedbackRequest(feedbackContent);
+
+        UserMission userMission = UserMission.builder().id(userMissionId).build();
+
+        when(userMissionRepository.findById(userMissionId)).thenReturn(Optional.of(userMission));
+        when(userMissionSubmissionRepository.findByUserMission(userMission)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(SubmissionNotFoundException.class, () -> {
+            missionService.updateSubmissionFeedback(userMissionId, request);
+        });
+
+        // save 메서드가 호출되지 않았는지 검증
+        verify(userMissionSubmissionRepository, never()).save(any(Submission.class));
     }
 }

--- a/src/test/java/org/example/hugmeexp/domain/mission/service/MissionServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/mission/service/MissionServiceTest.java
@@ -595,9 +595,7 @@ class MissionServiceTest {
         when(userMissionSubmissionRepository.existsByUserMission(userMission)).thenReturn(true);
 
         // When & Then
-        assertThrows(AlreadyExistsUserMissionSubmissionException.class, () -> {
-            missionService.submitChallenge(userMissionId, request, file);
-        });
+        assertThrows(AlreadyExistsUserMissionSubmissionException.class, () -> missionService.submitChallenge(userMissionId, request, file));
 
         // save 메서드가 호출되지 않았는지 검증
         verify(userMissionSubmissionRepository, never()).save(any(Submission.class));
@@ -614,9 +612,7 @@ class MissionServiceTest {
         when(userMissionRepository.findById(userMissionId)).thenReturn(Optional.empty());
 
         // When & Then
-        assertThrows(UserMissionNotFoundException.class, () -> {
-            missionService.submitChallenge(userMissionId, request, file);
-        });
+        assertThrows(UserMissionNotFoundException.class, () -> missionService.submitChallenge(userMissionId, request, file));
     }
 
     @Test
@@ -641,9 +637,7 @@ class MissionServiceTest {
 
         // When & Then
         // RuntimeException인 SubmissionFileUploadException이 발생하는지 확인
-        assertThrows(SubmissionFileUploadException.class, () -> {
-            missionService.submitChallenge(userMissionId, request, mockFile);
-        });
+        assertThrows(SubmissionFileUploadException.class, () -> missionService.submitChallenge(userMissionId, request, mockFile));
 
         // @Transactional에 의해 롤백되므로 save는 호출되지만 커밋되지 않음.
         // 테스트에서는 save가 호출되었는지 여부만 확인할 수 있음.
@@ -683,9 +677,7 @@ class MissionServiceTest {
         when(userMissionSubmissionRepository.findByUserMission(userMission)).thenReturn(Optional.empty());
 
         // When & Then
-        assertThrows(SubmissionNotFoundException.class, () -> {
-            missionService.getSubmissionByMissionId(userMissionId);
-        });
+        assertThrows(SubmissionNotFoundException.class, () -> missionService.getSubmissionByMissionId(userMissionId));
     }
 
     @Test
@@ -729,9 +721,7 @@ class MissionServiceTest {
         when(userMissionSubmissionRepository.findByUserMission(userMission)).thenReturn(Optional.empty());
 
         // When & Then
-        assertThrows(SubmissionNotFoundException.class, () -> {
-            missionService.updateSubmissionFeedback(userMissionId, request);
-        });
+        assertThrows(SubmissionNotFoundException.class, () -> missionService.updateSubmissionFeedback(userMissionId, request));
 
         // save 메서드가 호출되지 않았는지 검증
         verify(userMissionSubmissionRepository, never()).save(any(Submission.class));


### PR DESCRIPTION
미션 제출 및 피드백 기능 구현입니다.

```yml
file:
  submission-upload-dir: blah
```
위 설정이 추가 되었습니다.

체크리스트에는 없지만 Multipart Formdata에 File이 누락된 경우의 예외 처리를 global ExceptionController에 추가했습니다.

TODO:
ERD 수정

closes #74 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 미션 제출 및 피드백 관리 기능이 추가되었습니다. 사용자는 챌린지에 파일과 코멘트를 첨부하여 제출할 수 있으며, 제출된 미션의 상세 정보 조회, 파일 다운로드, 피드백 등록 및 수정이 가능합니다.
- **버그 수정**
    - 요청 파라미터 누락 시 명확한 오류 메시지와 함께 400 Bad Request 응답이 제공됩니다.
- **테스트**
    - 미션 제출, 중복 제출 방지, 파일 업로드 오류, 제출 조회, 피드백 등록 등 신규 기능에 대한 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->