### PR TITLE
댓글 삭제 기능

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/praise/controller/CommentController.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/controller/CommentController.java
@@ -44,10 +44,12 @@ public class CommentController {
     }
 
     /* 댓글 삭제 */
-    @DeleteMapping("/{commentId}")
-    public ResponseEntity<Response<Void>> deleteComment(@PathVariable Long commentId){
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<Response<Void>> deleteComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal CustomUserDetails userDetails){
 
-        commentService.deleteComment(commentId);
+        commentService.deleteComment(commentId, userDetails.getUser());
 
         Response<Void> response = Response.<Void>builder()
                 .message("댓글 삭제 완료")
@@ -56,4 +58,5 @@ public class CommentController {
 
         return ResponseEntity.ok(response);
     }
+
 }

--- a/src/main/java/org/example/hugmeexp/domain/praise/exception/ForbiddenCommentAccessException.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/exception/ForbiddenCommentAccessException.java
@@ -1,0 +1,10 @@
+package org.example.hugmeexp.domain.praise.exception;
+
+import org.example.hugmeexp.global.common.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+public class ForbiddenCommentAccessException extends BaseCustomException {
+    public ForbiddenCommentAccessException() {
+        super(HttpStatus.FORBIDDEN,"댓글 삭제 권한이 없습니다",403);
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/praise/service/PraiseService.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/service/PraiseService.java
@@ -38,6 +38,7 @@ public class PraiseService {
     private final UserRepository userRepository;
     private final PraiseReceiverRepository praiseReceiverRepository;
     private final CommentEmojiReactionRepository commentEmojiReactionRepository;
+    private final CommentService commentService;
 
 
     /* 칭찬 생성 */
@@ -278,7 +279,7 @@ public class PraiseService {
         List<PraiseReceiver> receiverList = praiseReceiverRepository.findByPraise(praise);
 
         // 댓글 목록 조회
-        List<PraiseComment> commentList = commentRepository.findByPraise(praise);
+        List<PraiseComment> commentList = commentService.getCommentsByPraise(praise);
 
         // 이모지 반응 수 조회
         List<Object[]> counts = praiseEmojiReactionRepository.countGroupedByEmoji(praise);


### PR DESCRIPTION
close #87 
Commit
- 댓글 삭제 기능 구현 
Update
- 댓글 상세조회 수정
![스크린샷 2025-06-24 020636](https://github.com/user-attachments/assets/7680ae75-7f27-4a03-8720-5eaf9bc4f5a4)
![스크린샷 2025-06-24 020659](https://github.com/user-attachments/assets/9c4c4531-37a0-496b-894f-a8d36e138c9b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 댓글 삭제 시 작성자 본인만 삭제할 수 있도록 권한 검증이 추가되었습니다.
	- 댓글 삭제 권한이 없을 경우 403 오류가 반환됩니다.

- **버그 수정**
	- 댓글 삭제 엔드포인트의 URL이 `/comments/{commentId}`로 변경되었습니다.

- **리팩터링**
	- 댓글 목록 조회가 일관된 서비스 계층을 통해 처리되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->