### PR TITLE
칭찬 게시물 반응 삭제

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/praise/controller/CommentController.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/controller/CommentController.java
@@ -40,7 +40,7 @@ public class CommentController {
                 .data(result)
                 .build();
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     /* 댓글 삭제 */

--- a/src/main/java/org/example/hugmeexp/domain/praise/controller/PraiseEmojiReactionController.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/controller/PraiseEmojiReactionController.java
@@ -3,7 +3,6 @@ package org.example.hugmeexp.domain.praise.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.hugmeexp.domain.praise.dto.PraiseDetailResponseDTO;
 import org.example.hugmeexp.domain.praise.dto.PraiseEmojiReactionRequestDTO;
 import org.example.hugmeexp.domain.praise.dto.PraiseEmojiReactionResponseDTO;
 import org.example.hugmeexp.domain.praise.service.PraiseEmojiReactionService;
@@ -49,6 +48,9 @@ public class PraiseEmojiReactionController {
             @PathVariable Long emojiId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ){
+        log.info("Praise emoji reaction deletion request - praiseId: {}, emojiId: {}, userId: {}",
+                praiseId, emojiId, userDetails.getUser().getId());
+
         praiseEmojiReactionService.deleteEmojiReaction(praiseId,emojiId,userDetails.getUser());
 
         Response<Void> response = Response.<Void>builder()

--- a/src/main/java/org/example/hugmeexp/domain/praise/controller/PraiseEmojiReactionController.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/controller/PraiseEmojiReactionController.java
@@ -41,4 +41,22 @@ public class PraiseEmojiReactionController {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
+
+    /* 칭찬 게시물에 반응 삭제 */
+    @DeleteMapping("/{praiseId}/emojis/{emojiId}")
+    public ResponseEntity<Response<Void>> deleteEmojiReaction(
+            @PathVariable Long praiseId,
+            @PathVariable Long emojiId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ){
+        praiseEmojiReactionService.deleteEmojiReaction(praiseId,emojiId,userDetails.getUser());
+
+        Response<Void> response = Response.<Void>builder()
+                .message("칭찬 게시물 반응 삭제 완료")
+                .data(null)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/org/example/hugmeexp/domain/praise/exception/InvalidPraiseEmojiAccessException.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/exception/InvalidPraiseEmojiAccessException.java
@@ -5,6 +5,6 @@ import org.springframework.http.HttpStatus;
 
 public class InvalidPraiseEmojiAccessException extends BaseCustomException {
     public InvalidPraiseEmojiAccessException() {
-        super(HttpStatus.BAD_REQUEST,"칭찬 게시물의 실제 반응와 일치하지 않습니다.",400);
+        super(HttpStatus.BAD_REQUEST,"칭찬 게시물의 실제 반응과 일치하지 않습니다.",400);
     }
 }

--- a/src/main/java/org/example/hugmeexp/domain/praise/exception/InvalidPraiseEmojiAccessException.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/exception/InvalidPraiseEmojiAccessException.java
@@ -1,0 +1,10 @@
+package org.example.hugmeexp.domain.praise.exception;
+
+import org.example.hugmeexp.global.common.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidPraiseEmojiAccessException extends BaseCustomException {
+    public InvalidPraiseEmojiAccessException() {
+        super(HttpStatus.BAD_REQUEST,"칭찬 게시물의 실제 반응와 일치하지 않습니다.",400);
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/praise/exception/PraiseEmojiReactionNotFoundException.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/exception/PraiseEmojiReactionNotFoundException.java
@@ -1,0 +1,10 @@
+package org.example.hugmeexp.domain.praise.exception;
+
+import org.example.hugmeexp.global.common.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+public class PraiseEmojiReactionNotFoundException extends BaseCustomException {
+    public PraiseEmojiReactionNotFoundException() {
+        super(HttpStatus.NOT_FOUND,"칭찬 게시물에 반응이 없습니다.",404);
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/praise/exception/UnauthorizedEmojiDeleteException.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/exception/UnauthorizedEmojiDeleteException.java
@@ -1,0 +1,10 @@
+package org.example.hugmeexp.domain.praise.exception;
+
+import org.example.hugmeexp.global.common.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedEmojiDeleteException extends BaseCustomException {
+    public UnauthorizedEmojiDeleteException() {
+        super(HttpStatus.FORBIDDEN,"이모지 삭제 권한이 없습니다",403);
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/praise/repository/PraiseEmojiReactionRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/repository/PraiseEmojiReactionRepository.java
@@ -23,8 +23,9 @@ public interface PraiseEmojiReactionRepository extends JpaRepository<PraiseEmoji
     /* 특정 칭찬 글에 달린 모든 이모지 반응을 조회 */
     List<PraiseEmojiReaction> findByPraise(Praise praise);
 
-    /* 특정 칭찬 글에서 특정 이모징 ㅔ대한 반응만 조회 */
+    /* 특정 칭찬 글에서 특정 이모지에 대한 반응만 조회 */
     List<PraiseEmojiReaction> findByPraiseAndEmoji(Praise praise, String emoji);
 
+    /* 특정 이모지로 이미 반응한 적이 있는지 여부 반환 */
     boolean existsByPraiseAndReactorWriterAndEmoji(Praise praise, User reactorWriter, String emoji);
 }

--- a/src/main/java/org/example/hugmeexp/domain/praise/service/PraiseEmojiReactionService.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/service/PraiseEmojiReactionService.java
@@ -6,9 +6,7 @@ import org.example.hugmeexp.domain.praise.dto.PraiseEmojiReactionRequestDTO;
 import org.example.hugmeexp.domain.praise.dto.PraiseEmojiReactionResponseDTO;
 import org.example.hugmeexp.domain.praise.entity.Praise;
 import org.example.hugmeexp.domain.praise.entity.PraiseEmojiReaction;
-import org.example.hugmeexp.domain.praise.exception.DuplicateEmojiReactionException;
-import org.example.hugmeexp.domain.praise.exception.InvalidEmojiException;
-import org.example.hugmeexp.domain.praise.exception.PraiseNotFoundException;
+import org.example.hugmeexp.domain.praise.exception.*;
 import org.example.hugmeexp.domain.praise.mapper.PraiseEmojiReactionMapper;
 import org.example.hugmeexp.domain.praise.repository.PraiseEmojiReactionRepository;
 import org.example.hugmeexp.domain.praise.repository.PraiseRepository;
@@ -65,4 +63,24 @@ public class PraiseEmojiReactionService {
         return PraiseEmojiReactionResponseDTO.from(saved, sameEmojiReactions);
     }
 
+    /* 칭찬 게시물에 반응 삭제 */
+    @Transactional
+    public void deleteEmojiReaction(Long praiseId, Long emojiId, User user) {
+
+        // 이모지 반응 조회
+        PraiseEmojiReaction reaction = praiseEmojiReactionRepository.findById(emojiId)
+                .orElseThrow(() -> new PraiseEmojiReactionNotFoundException());
+
+        // URL 의 praiseId 와 실제 반응의 praiseId 일치 여부 확인
+        if(!reaction.getPraise().getId().equals(praiseId)){
+            throw new InvalidPraiseEmojiAccessException();
+        }
+
+        // 본인만 삭제할 수 있도록 작성자 확인
+        if (!reaction.getReactorWriter().getId().equals(user.getId())){
+            throw new UnauthorizedEmojiDeleteException();
+        }
+
+        praiseEmojiReactionRepository.delete(reaction);
+    }
 }


### PR DESCRIPTION
Close #96 
Commit
- 칭찬 게시물 반응 삭제 구현
![스크린샷 2025-06-24 205947](https://github.com/user-attachments/assets/8a877205-c4c5-4920-9300-f6d1a64e24c6)
![스크린샷 2025-06-24 210022](https://github.com/user-attachments/assets/e9c2f084-0612-4eb6-b57b-656193594a80)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 칭찬 게시물에서 이모지 반응을 삭제할 수 있는 엔드포인트가 추가되었습니다.

- **버그 수정**
	- 댓글 생성 시 반환되는 HTTP 상태 코드가 200 OK에서 201 Created로 변경되었습니다.

- **문서화**
	- 주석 오타 수정 및 설명이 보완되었습니다.

- **에러 처리**
	- 이모지 반응 삭제 시 발생할 수 있는 다양한 예외(존재하지 않는 반응, 권한 없음, 잘못된 접근)에 대한 예외 처리가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->