### PR TITLE
Feature/#99 미션 제출 업로드 경로 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 *.yml
 /profile-images/
 /product-images/
+/mission-uploads/

--- a/src/main/java/org/example/hugmeexp/domain/mission/controller/SubmissionController.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/controller/SubmissionController.java
@@ -10,14 +10,12 @@ import org.example.hugmeexp.domain.mission.exception.SubmissionNotFoundException
 import org.example.hugmeexp.domain.mission.service.MissionService;
 import org.example.hugmeexp.domain.mission.util.FileUploadUtils;
 import org.example.hugmeexp.global.common.response.Response;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.File;

--- a/src/main/java/org/example/hugmeexp/domain/mission/controller/SubmissionController.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/controller/SubmissionController.java
@@ -49,7 +49,7 @@ public class SubmissionController {
         String savedFileName = FileUploadUtils.getSafeFileName(submissionResponse.getFileName());
         String originalFileName = FileUploadUtils.getSafeFileName(submissionResponse.getOriginalFileName());
 
-        String uploadDir = FileUploadUtils.getUploadDir(FileUploadType.MISSION_UPLOADS).toString();
+        String uploadDir = FileUploadUtils.getUploadPath(FileUploadType.MISSION_UPLOADS).toString();
 
         File file = new File(uploadDir, savedFileName);
 

--- a/src/main/java/org/example/hugmeexp/domain/mission/controller/SubmissionController.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/controller/SubmissionController.java
@@ -49,7 +49,7 @@ public class SubmissionController {
         String savedFileName = FileUploadUtils.getSafeFileName(submissionResponse.getFileName());
         String originalFileName = FileUploadUtils.getSafeFileName(submissionResponse.getOriginalFileName());
 
-        String uploadDir = FileUploadUtils.getUploadDir(FileUploadType.MISSION_UPLOADS);
+        String uploadDir = FileUploadUtils.getUploadDir(FileUploadType.MISSION_UPLOADS).toString();
 
         File file = new File(uploadDir, savedFileName);
 

--- a/src/main/java/org/example/hugmeexp/domain/mission/controller/SubmissionController.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/controller/SubmissionController.java
@@ -4,9 +4,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.hugmeexp.domain.mission.dto.request.SubmissionFeedbackRequest;
 import org.example.hugmeexp.domain.mission.dto.response.SubmissionResponse;
+import org.example.hugmeexp.domain.mission.enums.FileUploadType;
 import org.example.hugmeexp.domain.mission.exception.SubMissionInternalException;
 import org.example.hugmeexp.domain.mission.exception.SubmissionNotFoundException;
 import org.example.hugmeexp.domain.mission.service.MissionService;
+import org.example.hugmeexp.domain.mission.util.FileUploadUtils;
 import org.example.hugmeexp.global.common.response.Response;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.FileSystemResource;
@@ -28,8 +30,6 @@ import java.nio.charset.StandardCharsets;
 public class SubmissionController {
     private final MissionService missionService;
 
-    @Value("${file.submission-upload-dir}")
-    private String uploadDir;
 
     @GetMapping("/{userMissionId}")
     public ResponseEntity<Response<?>> getSubmissionByMissionId(@PathVariable Long userMissionId) {
@@ -48,8 +48,11 @@ public class SubmissionController {
         }
 
         // 둘 모두 이미 검증된 파일명이지만 다시 한 번 검증
-        String savedFileName = getSafeFileName(submissionResponse.getFileName());
-        String originalFileName = getSafeFileName(submissionResponse.getOriginalFileName()).replaceAll("[^a-zA-Z0-9가-힣._-]", "_");;
+        String savedFileName = FileUploadUtils.getSafeFileName(submissionResponse.getFileName());
+        String originalFileName = FileUploadUtils.getSafeFileName(submissionResponse.getOriginalFileName());
+
+        String uploadDir = FileUploadUtils.getUploadDir(FileUploadType.MISSION_UPLOADS);
+
         File file = new File(uploadDir, savedFileName);
 
         try {
@@ -91,13 +94,5 @@ public class SubmissionController {
         return ResponseEntity.ok(Response.builder()
                 .message("제출 피드백이 성공적으로 업데이트되었습니다.")
                 .build());
-    }
-
-    private static String getSafeFileName(String fileName) {
-        if (fileName == null || fileName.isEmpty()) {
-            throw new SubMissionInternalException("파일 이름이 비어 있거나 null입니다.");
-        }
-
-        return StringUtils.getFilename(StringUtils.cleanPath(fileName));
     }
 }

--- a/src/main/java/org/example/hugmeexp/domain/mission/enums/FileUploadType.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/enums/FileUploadType.java
@@ -1,0 +1,17 @@
+package org.example.hugmeexp.domain.mission.enums;
+
+public enum FileUploadType {
+    MISSION_UPLOADS("/mission-uploads/"),
+    PROFILE_IMAGES("/profile-images/"),
+    PRODUCT_IMAGES("/product-images/");
+
+    private final String value;
+
+    FileUploadType(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/mission/enums/FileUploadType.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/enums/FileUploadType.java
@@ -1,9 +1,9 @@
 package org.example.hugmeexp.domain.mission.enums;
 
 public enum FileUploadType {
-    MISSION_UPLOADS("/mission-uploads/"),
-    PROFILE_IMAGES("/profile-images/"),
-    PRODUCT_IMAGES("/product-images/");
+    MISSION_UPLOADS("mission-uploads"),
+    PROFILE_IMAGES("profile-images"),
+    PRODUCT_IMAGES("product-images");
 
     private final String value;
 

--- a/src/main/java/org/example/hugmeexp/domain/mission/service/MissionServiceImpl.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/service/MissionServiceImpl.java
@@ -189,7 +189,7 @@ public class MissionServiceImpl implements MissionService {
             throw new AlreadyExistsUserMissionSubmissionException();
         }
 
-        String uploadDir = FileUploadUtils.getUploadDir(FileUploadType.MISSION_UPLOADS).toString();
+        String uploadDir = FileUploadUtils.getUploadPath(FileUploadType.MISSION_UPLOADS).toString();
 
         Submission submission = userMissionSubmissionMapper.toEntity(submissionUploadRequest);
 

--- a/src/main/java/org/example/hugmeexp/domain/mission/service/MissionServiceImpl.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/service/MissionServiceImpl.java
@@ -28,13 +28,10 @@ import org.example.hugmeexp.domain.missionGroup.repository.MissionGroupRepositor
 import org.example.hugmeexp.domain.missionGroup.repository.UserMissionGroupRepository;
 import org.example.hugmeexp.domain.user.entity.User;
 import org.example.hugmeexp.domain.user.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.UUID;
 

--- a/src/main/java/org/example/hugmeexp/domain/mission/service/MissionServiceImpl.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/service/MissionServiceImpl.java
@@ -189,7 +189,7 @@ public class MissionServiceImpl implements MissionService {
             throw new AlreadyExistsUserMissionSubmissionException();
         }
 
-        String uploadDir = FileUploadUtils.getUploadDir(FileUploadType.MISSION_UPLOADS);
+        String uploadDir = FileUploadUtils.getUploadDir(FileUploadType.MISSION_UPLOADS).toString();
 
         Submission submission = userMissionSubmissionMapper.toEntity(submissionUploadRequest);
 

--- a/src/main/java/org/example/hugmeexp/domain/mission/service/MissionServiceImpl.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/service/MissionServiceImpl.java
@@ -11,6 +11,7 @@ import org.example.hugmeexp.domain.mission.dto.response.UserMissionResponse;
 import org.example.hugmeexp.domain.mission.entity.Mission;
 import org.example.hugmeexp.domain.mission.entity.UserMission;
 import org.example.hugmeexp.domain.mission.entity.Submission;
+import org.example.hugmeexp.domain.mission.enums.FileUploadType;
 import org.example.hugmeexp.domain.mission.enums.UserMissionState;
 import org.example.hugmeexp.domain.mission.exception.*;
 import org.example.hugmeexp.domain.mission.mapper.MissionMapper;
@@ -19,6 +20,7 @@ import org.example.hugmeexp.domain.mission.mapper.UserMissionSubmissionMapper;
 import org.example.hugmeexp.domain.mission.repository.MissionRepository;
 import org.example.hugmeexp.domain.mission.repository.UserMissionRepository;
 import org.example.hugmeexp.domain.mission.repository.UserMissionSubmissionRepository;
+import org.example.hugmeexp.domain.mission.util.FileUploadUtils;
 import org.example.hugmeexp.domain.missionGroup.entity.MissionGroup;
 import org.example.hugmeexp.domain.missionGroup.entity.UserMissionGroup;
 import org.example.hugmeexp.domain.missionGroup.exception.MissionGroupNotFoundException;
@@ -31,6 +33,8 @@ import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.UUID;
 
@@ -50,9 +54,6 @@ public class MissionServiceImpl implements MissionService {
     private final UserMissionMapper userMissionMapper;
     private final UserMissionSubmissionRepository userMissionSubmissionRepository;
     private final UserMissionSubmissionMapper userMissionSubmissionMapper;
-
-    @Value("${file.submission-upload-dir}")
-    private String uploadDir;
 
     @Override
     @Transactional
@@ -191,11 +192,26 @@ public class MissionServiceImpl implements MissionService {
             throw new AlreadyExistsUserMissionSubmissionException();
         }
 
+        String uploadDir = FileUploadUtils.getUploadDir(FileUploadType.MISSION_UPLOADS);
+
         Submission submission = userMissionSubmissionMapper.toEntity(submissionUploadRequest);
 
         submission.setUserMission(userMission);
 
-        String safeFileName = getSafeFileName(file);
+        if (file == null || file.isEmpty())
+        {
+            throw new SubmissionFileUploadException("파일이 비어있거나 존재하지 않습니다.");
+        } else if (
+                file.getOriginalFilename() == null ||
+                        file.getOriginalFilename().isEmpty() ||
+                        !file.getOriginalFilename().contains(".")
+        ) {
+            throw new SubmissionFileUploadException("파일 확장자가 없습니다.");
+        }
+
+        String originalFilename = file.getOriginalFilename();
+
+        String safeFileName = FileUploadUtils.getSafeFileName(originalFilename);
 
         // UUID를 사용하여 파일 이름을 안전하게 생성 및 중복 방지
         String fileName = UUID.randomUUID().toString();
@@ -213,23 +229,6 @@ public class MissionServiceImpl implements MissionService {
         } catch (IOException e) {
             throw new SubmissionFileUploadException("파일 저장 중 오류가 발생했습니다."); // RuntimeException을 던져서 IOException이 나더라도 롤백되게 함
         }
-    }
-
-    private static String getSafeFileName(MultipartFile file) {
-        if (file == null || file.isEmpty())
-        {
-            throw new SubmissionFileUploadException("파일이 비어있거나 존재하지 않습니다.");
-        } else if (
-            file.getOriginalFilename() == null ||
-            file.getOriginalFilename().isEmpty() ||
-            !file.getOriginalFilename().contains(".")
-        ) {
-            throw new SubmissionFileUploadException("파일 확장자가 없습니다.");
-        }
-
-        String originalFilename = file.getOriginalFilename();
-
-        return new File(originalFilename).getName().replaceAll("[^a-zA-Z0-9가-힣._-]", "_");
     }
 
     @Override

--- a/src/main/java/org/example/hugmeexp/domain/mission/util/FileUploadUtils.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/util/FileUploadUtils.java
@@ -1,0 +1,29 @@
+package org.example.hugmeexp.domain.mission.util;
+
+import org.example.hugmeexp.domain.mission.enums.FileUploadType;
+import org.example.hugmeexp.domain.mission.exception.SubMissionInternalException;
+import org.example.hugmeexp.domain.mission.exception.SubmissionFileUploadException;
+import org.springframework.util.StringUtils;
+
+import java.nio.file.*;
+
+public final class FileUploadUtils {
+    private FileUploadUtils() {}
+
+    public static String getUploadDir(FileUploadType uploadType) {
+        // 절대 경로와 현재 작업 경로 조합, 필요에 따라 수정 가능
+        Path uploadDir = Paths.get(uploadType.value(), System.getProperty("user.dir"));
+        if (!Files.exists(uploadDir) && !uploadDir.toFile().mkdirs()) {
+            throw new SubmissionFileUploadException("업로드 디렉토리를 생성할 수 없습니다.");
+        }
+        return uploadDir.toString();
+    }
+
+    public static String getSafeFileName(String fileName) {
+        if (fileName == null || fileName.isEmpty()) {
+            throw new SubMissionInternalException("파일 이름이 비어 있거나 null입니다.");
+        }
+
+        return StringUtils.getFilename(StringUtils.cleanPath(fileName));
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/mission/util/FileUploadUtils.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/util/FileUploadUtils.java
@@ -11,8 +11,7 @@ import java.nio.file.*;
 public final class FileUploadUtils {
     private FileUploadUtils() {}
 
-    public static Path getUploadDir(FileUploadType uploadType) {
-        // 절대 경로와 현재 작업 경로 조합, 필요에 따라 수정 가능
+    public static Path getUploadPath(FileUploadType uploadType) {
         Path uploadDir = Paths.get(System.getProperty("user.dir"), uploadType.value());
         if (!Files.exists(uploadDir)) {
             try {
@@ -25,10 +24,28 @@ public final class FileUploadUtils {
     }
 
     public static String getSafeFileName(String fileName) {
+        // 파일 이름이 null이거나 비어 있는지 확인
         if (fileName == null || fileName.isEmpty()) {
             throw new SubMissionInternalException("파일 이름이 비어 있거나 null입니다.");
         }
 
-        return StringUtils.getFilename(StringUtils.cleanPath(fileName));
+        // 위험한 문자 패턴 검증
+        if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
+            throw new SubMissionInternalException("허용되지 않는 문자가 포함된 파일명입니다.");
+        }
+
+        // 파일명 길이 제한
+        if (fileName.length() > 255) {
+            throw new SubMissionInternalException("파일명이 너무 깁니다.");
+        }
+
+        String cleanedFileName = StringUtils.getFilename(StringUtils.cleanPath(fileName));
+
+        // 최종 검증
+        if (cleanedFileName == null || cleanedFileName.isEmpty()) {
+            throw new SubMissionInternalException("유효하지 않은 파일명입니다.");
+        }
+
+        return cleanedFileName;
     }
 }

--- a/src/main/java/org/example/hugmeexp/domain/mission/util/FileUploadUtils.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/util/FileUploadUtils.java
@@ -12,7 +12,7 @@ public final class FileUploadUtils {
 
     public static String getUploadDir(FileUploadType uploadType) {
         // 절대 경로와 현재 작업 경로 조합, 필요에 따라 수정 가능
-        Path uploadDir = Paths.get(uploadType.value(), System.getProperty("user.dir"));
+        Path uploadDir = Paths.get(System.getProperty("user.dir"), uploadType.value());
         if (!Files.exists(uploadDir) && !uploadDir.toFile().mkdirs()) {
             throw new SubmissionFileUploadException("업로드 디렉토리를 생성할 수 없습니다.");
         }

--- a/src/main/java/org/example/hugmeexp/domain/mission/util/FileUploadUtils.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/util/FileUploadUtils.java
@@ -5,18 +5,23 @@ import org.example.hugmeexp.domain.mission.exception.SubMissionInternalException
 import org.example.hugmeexp.domain.mission.exception.SubmissionFileUploadException;
 import org.springframework.util.StringUtils;
 
+import java.io.IOException;
 import java.nio.file.*;
 
 public final class FileUploadUtils {
     private FileUploadUtils() {}
 
-    public static String getUploadDir(FileUploadType uploadType) {
+    public static Path getUploadDir(FileUploadType uploadType) {
         // 절대 경로와 현재 작업 경로 조합, 필요에 따라 수정 가능
         Path uploadDir = Paths.get(System.getProperty("user.dir"), uploadType.value());
-        if (!Files.exists(uploadDir) && !uploadDir.toFile().mkdirs()) {
-            throw new SubmissionFileUploadException("업로드 디렉토리를 생성할 수 없습니다.");
+        if (!Files.exists(uploadDir)) {
+            try {
+                Files.createDirectories(uploadDir);
+            } catch (IOException e) {
+                throw new SubmissionFileUploadException("업로드 디렉토리를 생성할 수 없습니다.");
+            }
         }
-        return uploadDir.toString();
+        return uploadDir;
     }
 
     public static String getSafeFileName(String fileName) {

--- a/src/test/java/org/example/hugmeexp/domain/mission/service/MissionServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/mission/service/MissionServiceTest.java
@@ -549,7 +549,7 @@ class MissionServiceTest {
 
         try (MockedStatic<FileUploadUtils> mockedStatic = Mockito.mockStatic(FileUploadUtils.class)) {
             FileUploadType fileUploadType = FileUploadType.MISSION_UPLOADS;
-            mockedStatic.when(() -> FileUploadUtils.getUploadDir(fileUploadType))
+            mockedStatic.when(() -> FileUploadUtils.getUploadPath(fileUploadType))
                     .thenReturn(tempDir);
             mockedStatic.when(() -> FileUploadUtils.getSafeFileName(originalFileName))
                     .thenReturn(originalFileName);
@@ -625,7 +625,7 @@ class MissionServiceTest {
 
         try (MockedStatic<FileUploadUtils> mockedStatic = Mockito.mockStatic(FileUploadUtils.class)) {
             FileUploadType fileUploadType = FileUploadType.MISSION_UPLOADS;
-            mockedStatic.when(() -> FileUploadUtils.getUploadDir(fileUploadType))
+            mockedStatic.when(() -> FileUploadUtils.getUploadPath(fileUploadType))
                     .thenReturn(tempDir);
             mockedStatic.when(() -> FileUploadUtils.getSafeFileName(any(String.class)))
                     .thenReturn("valid.name.txt");


### PR DESCRIPTION
이제 아래 설정 없이도 동작합니다.
```yml
file:
  submission-upload-dir: ./uploads/submissions
```

경로는 아래 사진의 FileUploadUtils 에서 가져오도록 설정되었습니다.
![image](https://github.com/user-attachments/assets/a0f13d6c-6718-440a-be1a-206316f472b0)



closes #99 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정 및 리팩터**
  - 파일 업로드 처리 방식이 개선되어 파일 저장 경로와 파일명 검증이 더욱 안전하게 이루어집니다.
  - 업로드 대상 디렉터리 `/mission-uploads/`가 새로 추가되어 관리 범위가 확장되었습니다.
- **테스트**
  - 파일 업로드 관련 테스트 코드가 안정적으로 동작하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->