### PR TITLE
refactor: 상품 이미지 응답 경로 수정

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/shop/mapper/ProductMapper.java
+++ b/src/main/java/org/example/hugmeexp/domain/shop/mapper/ProductMapper.java
@@ -15,7 +15,18 @@ public interface ProductMapper {
 
     @Named("toImageUrl")
     static String toImageUrl(ProductImage image) {
-        if (image == null) return null;
-        return String.format("%s\\%s.%s", image.getPath(), image.getUuid(), image.getExtension());
+
+        String internalPath = image.getPath();
+        String uuid = image.getUuid();
+        String ext = image.getExtension();
+
+        String fullPath = internalPath + "/" + uuid + "." + ext;
+
+        // "/application" 제거
+        if (fullPath.startsWith("/application")) {
+            return fullPath.substring("/application".length());
+        }
+
+        return fullPath;
     }
 }


### PR DESCRIPTION
## 변경 사항
- product image의 응답 경로 /application/product-images/~~ -> /product-images/~~
![image](https://github.com/user-attachments/assets/1ce46e7e-0ab5-46f9-ba67-0a27ca44a7c8)
![image](https://github.com/user-attachments/assets/757442cb-da6a-4276-9085-9bb876b2eb7b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 상품 이미지 URL 경로가 올바르게 표시되도록 경로 구분자가 수정되고, 불필요한 접두사가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->