### PR TITLE
칭찬 댓글 반응 삭제 기능 구현

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/praise/controller/CommentEmojiReactionController.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/controller/CommentEmojiReactionController.java
@@ -41,19 +41,23 @@ public class CommentEmojiReactionController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    /* 반응 삭제 */
-//    @DeleteMapping
-//    public ResponseEntity<Response<Void>> deleteReaction(@PathVariable Long reactionId){
-//
-//        log.info("반응 삭제 요청 : {}", reactionId);
-//
-//        commentEmojiReactionService.deleteReaction(reactionId);
-//
-//        Response<Void> response = Response.<Void>builder()
-//                .message("반응 삭제 완료")
-//                .data(null)
-//                .build();
-//
-//        return ResponseEntity.ok(response);
-//    }
+    /* 댓글 반응 삭제 */
+    @DeleteMapping("/{praiseId}/comments/{commentId}/emojis/{emojiId}")
+    public ResponseEntity<Response<Void>> deleteReaction(
+            @PathVariable Long praiseId,
+            @PathVariable Long commentId,
+            @PathVariable Long emojiId,
+            @AuthenticationPrincipal CustomUserDetails userDetails){
+
+        log.info("반응 삭제 요청 : {}", emojiId);
+
+        commentEmojiReactionService.deleteCommentReaction(praiseId,commentId,emojiId,userDetails.getUser());
+
+        Response<Void> response = Response.<Void>builder()
+                .message("반응 삭제 완료")
+                .data(null)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/org/example/hugmeexp/domain/praise/exception/CommentEmojiReactionNotFoundException.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/exception/CommentEmojiReactionNotFoundException.java
@@ -1,0 +1,10 @@
+package org.example.hugmeexp.domain.praise.exception;
+
+import org.example.hugmeexp.global.common.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+public class CommentEmojiReactionNotFoundException extends BaseCustomException {
+    public CommentEmojiReactionNotFoundException() {
+        super(HttpStatus.NOT_FOUND,"댓글 반응을 찾을 수 없습니다",404);
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/praise/exception/MismatchedCommentReactionException.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/exception/MismatchedCommentReactionException.java
@@ -1,0 +1,10 @@
+package org.example.hugmeexp.domain.praise.exception;
+
+import org.example.hugmeexp.global.common.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+public class MismatchedCommentReactionException extends BaseCustomException {
+    public MismatchedCommentReactionException() {
+        super(HttpStatus.BAD_REQUEST,"반응이 해당 댓글에 속하지 않습니다.",400);
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/praise/service/CommentEmojiReactionService.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/service/CommentEmojiReactionService.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import org.example.hugmeexp.domain.praise.dto.CommentEmojiReactionRequestDTO;
 import org.example.hugmeexp.domain.praise.dto.CommentEmojiReactionResponseDTO;
 import org.example.hugmeexp.domain.praise.entity.PraiseComment;
-import org.example.hugmeexp.domain.praise.entity.Praise;
 import org.example.hugmeexp.domain.praise.entity.CommentEmojiReaction;
 import org.example.hugmeexp.domain.praise.exception.*;
 import org.example.hugmeexp.domain.praise.mapper.CommentEmojiReactionMapper;
@@ -68,5 +67,32 @@ public class CommentEmojiReactionService {
 
         return CommentEmojiReactionResponseDTO.from(commentEmojiReaction);
 
+    }
+
+    /* 댓글 반응 삭제 */
+    @Transactional
+    public void deleteCommentReaction(Long praiseId, Long commentId, Long emojiId, User user) {
+
+        // 이모지 반응 존재 확인
+        CommentEmojiReaction commentEmojiReaction = commentEmojiReactionRepository.findById(emojiId)
+                .orElseThrow(()-> new CommentEmojiReactionNotFoundException());
+
+        // 댓글과 반응 연결 확인
+        if(!commentEmojiReaction.getComment().getId().equals(commentId)){
+            throw new MismatchedCommentReactionException();
+        }
+
+        // 댓글이 해당 칭찬에 속하는지 확인
+        if(!commentEmojiReaction.getComment().getPraise().getId().equals(praiseId)){
+            throw new MismatchedPraiseCommentException();
+        }
+
+        // 작성자 본인 확인
+        if(!commentEmojiReaction.getReactorWriter().getId().equals(user.getId())){
+            throw new UnauthorizedEmojiDeleteException();
+        }
+
+        // 삭제
+        commentEmojiReactionRepository.delete(commentEmojiReaction);
     }
 }


### PR DESCRIPTION
Commit
- 칭찬 댓글 반응 삭제 기능 구현
![스크린샷 2025-06-25 112716](https://github.com/user-attachments/assets/6d64bd91-ebe0-4d72-ba33-1f563b4a9686)
![스크린샷 2025-06-25 112739](https://github.com/user-attachments/assets/152fddcc-b28f-4b53-9398-ce2b673f2a24)
![스크린샷 2025-06-25 112753](https://github.com/user-attachments/assets/116bab39-d9e3-414a-b789-f2883d4de356)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 댓글 이모지 반응 삭제 시, 해당 칭찬글, 댓글, 이모지, 사용자 정보를 기반으로 더욱 정확한 삭제가 가능해졌습니다.
- **버그 수정**
	- 존재하지 않거나 일치하지 않는 댓글 이모지 반응 삭제 시, 명확한 오류 메시지와 상태 코드(404, 400)를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->