### PR TITLE
칭찬 게시물 조회 시 프로필 이미지 조회 가능

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/praise/dto/CommentResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/dto/CommentResponseDTO.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.hugmeexp.domain.praise.entity.PraiseComment;
+import org.example.hugmeexp.domain.user.entity.User;
 
 import java.time.LocalDateTime;
 import java.util.Map;
@@ -17,14 +18,20 @@ public class CommentResponseDTO {
 
     private Long id;    // PK
     private String commenterName;    // 댓글 작성자 이름
+    private String commentProfile;
     private String content;    // 댓글 내용
     private Map<String, Integer> emojiReactions;    // 이모지별 반응 수
     private LocalDateTime createdAt;    // 작성 시간
 
     public static CommentResponseDTO from(PraiseComment comment, Map<String, Integer> emojiReactions){
+
+        User commenter = comment.getCommentWriter();
+        String profileImage = commenter.getStoredProfileImagePath();
+
         return CommentResponseDTO.builder()
                 .id(comment.getId())
                 .commenterName(comment.getCommentWriter().getName())
+                .commentProfile(profileImage)
                 .content(comment.getContent())
                 .emojiReactions(emojiReactions)
                 .createdAt(comment.getCreatedAt())

--- a/src/main/java/org/example/hugmeexp/domain/praise/dto/PraiseDetailResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/dto/PraiseDetailResponseDTO.java
@@ -8,7 +8,6 @@ import org.example.hugmeexp.domain.praise.entity.Praise;
 import org.example.hugmeexp.domain.praise.entity.PraiseComment;
 import org.example.hugmeexp.domain.praise.entity.PraiseReceiver;
 import org.example.hugmeexp.domain.praise.enums.PraiseType;
-import org.example.hugmeexp.domain.user.entity.User;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -22,19 +21,22 @@ public class PraiseDetailResponseDTO {
 
     private Long id;    // 칭찬 ID
     private String senderName;    // 칭찬을 보낸 사람
-    private List<String> receiverNames;    // 칭찬을 받은 사람
+    private List<ReceiverResponseDTO> receivers;
     private String content;    // 칭찬 내용
     private PraiseType type;    // 칭찬 타입
     private LocalDateTime createdAt;    // 칭찬을 작성한 시간
     private List<EmojiReactionGroupDTO> emojiReactions;    // 이모지별 반응 수
     private int commentCount;    // 댓글 수
     private List<CommentResponseDTO> comments;     // 댓글 리스트
-//    private String profileImageUrl;
 
-    public static PraiseDetailResponseDTO from(Praise praise, List<PraiseReceiver> receivers, List<PraiseComment> commentList, List<EmojiReactionGroupDTO> emojiReactions, Map<Long, Map<String,Integer>> commentEmojiMap){
+    public static PraiseDetailResponseDTO from(Praise praise,
+                                               List<PraiseReceiver> receivers,
+                                               List<PraiseComment> commentList,
+                                               List<EmojiReactionGroupDTO> emojiReactions,
+                                               Map<Long, Map<String,Integer>> commentEmojiMap){
 
-        List<String> receiverNames = receivers.stream()
-                .map(praiseReceiver -> praiseReceiver.getReceiver().getName())
+        List<ReceiverResponseDTO> receiverDTO = receivers.stream()
+                .map(ReceiverResponseDTO::from)
                 .toList();
 
         List<CommentResponseDTO> commentResponse = commentList.stream()
@@ -46,7 +48,7 @@ public class PraiseDetailResponseDTO {
         return PraiseDetailResponseDTO.builder()
                 .id(praise.getId())
                 .senderName(praise.getSender().getName())
-                .receiverNames(receiverNames)
+                .receivers(receiverDTO)
                 .content(praise.getContent())
                 .type(praise.getPraiseType())
                 .createdAt(praise.getCreatedAt())

--- a/src/main/java/org/example/hugmeexp/domain/praise/dto/PraiseResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/dto/PraiseResponseDTO.java
@@ -7,10 +7,10 @@ import lombok.NoArgsConstructor;
 import org.example.hugmeexp.domain.praise.entity.Praise;
 import org.example.hugmeexp.domain.praise.entity.PraiseReceiver;
 import org.example.hugmeexp.domain.praise.enums.PraiseType;
+import org.example.hugmeexp.domain.user.dto.response.UserProfileResponse;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 
 @Getter
 @NoArgsConstructor
@@ -20,26 +20,35 @@ public class PraiseResponseDTO {
 
     private Long id;    // PK
     private String senderName;    // 칭찬 보낸 사람 이름
-    private List<String> receiverName;    // 칭찬 받은 사람 이름
+    private List<ReceiverResponseDTO> receivers;
     private String content;    // 칭찬 내용
     private PraiseType type;    // 칭찬 타입
     private long commentCount;    // 댓글 개수
+    private List<String> commentProfiles;
     private List<EmojiReactionGroupDTO> emojis;    // 이모지별 반응 수
     private LocalDateTime createdAt;    // 작성 시간
 
-    public static PraiseResponseDTO from(Praise praise, List<PraiseReceiver> receivers, long commentCount, List<EmojiReactionGroupDTO> emojis){
+    public static PraiseResponseDTO from(Praise praise,
+                                         List<PraiseReceiver> receivers,
+                                         long commentCount,
+                                         List<EmojiReactionGroupDTO> emojis,
+                                         List<UserProfileResponse> commentPro){
 
-        List<String> receiverNames = receivers.stream()
-                .map(praiseReceiver -> praiseReceiver.getReceiver().getName())
+        List<ReceiverResponseDTO> receiverDTO = receivers.stream()
+                .map(ReceiverResponseDTO::from)
                 .toList();
+
+        List<String> commentProfiles = commentPro.stream()
+                .map(UserProfileResponse::getProfileImage).toList();
 
         return PraiseResponseDTO.builder()
                 .id(praise.getId())
                 .senderName(praise.getSender().getName())
-                .receiverName(receiverNames)
+                .receivers(receiverDTO)
                 .content(praise.getContent())
                 .type(praise.getPraiseType())
                 .commentCount(commentCount)
+                .commentProfiles(commentProfiles)
                 .emojis(emojis)
                 .createdAt(praise.getCreatedAt())
                 .build();

--- a/src/main/java/org/example/hugmeexp/domain/praise/dto/ReceiverResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/dto/ReceiverResponseDTO.java
@@ -1,0 +1,28 @@
+package org.example.hugmeexp.domain.praise.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.hugmeexp.domain.praise.entity.PraiseReceiver;
+import org.example.hugmeexp.domain.user.entity.User;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReceiverResponseDTO {
+
+    private String name;
+    private String profileImage;
+
+    public static ReceiverResponseDTO from(PraiseReceiver receiver){
+
+        User user = receiver.getReceiver();
+
+        return ReceiverResponseDTO.builder()
+                .name(user.getName())
+                .profileImage(user.getStoredProfileImagePath())
+                .build();
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/praise/dto/RecentPraiseSenderResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/dto/RecentPraiseSenderResponseDTO.java
@@ -4,7 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.hugmeexp.domain.user.dto.response.UserProfileResponse;
 import org.example.hugmeexp.domain.user.entity.User;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -13,10 +16,16 @@ import org.example.hugmeexp.domain.user.entity.User;
 public class RecentPraiseSenderResponseDTO {
 
     private String name;
+    private List<String> senderProfiles;
 
-    public static RecentPraiseSenderResponseDTO from(User user){
+    public static RecentPraiseSenderResponseDTO from(User user, List<UserProfileResponse> receiverPro){
+
+        List<String> senderProfiles = receiverPro.stream()
+                .map(UserProfileResponse::getProfileImage).toList();
+
         return RecentPraiseSenderResponseDTO.builder()
                 .name(user.getName())
+                .senderProfiles(senderProfiles)
                 .build();
 
     }

--- a/src/main/java/org/example/hugmeexp/domain/praise/mapper/PraiseMapper.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/mapper/PraiseMapper.java
@@ -5,6 +5,7 @@ import org.example.hugmeexp.domain.praise.dto.PraiseRequestDTO;
 import org.example.hugmeexp.domain.praise.dto.PraiseResponseDTO;
 import org.example.hugmeexp.domain.praise.entity.Praise;
 import org.example.hugmeexp.domain.praise.entity.PraiseReceiver;
+import org.example.hugmeexp.domain.user.dto.response.UserProfileResponse;
 import org.example.hugmeexp.domain.user.entity.User;
 import org.mapstruct.Mapper;
 
@@ -22,8 +23,8 @@ public interface PraiseMapper {
     }
 
 
-    default PraiseResponseDTO toDTO(Praise praise, List<PraiseReceiver> praiseReceivers, long commentCount, List<EmojiReactionGroupDTO> emojiGroups){
+    default PraiseResponseDTO toDTO(Praise praise, List<PraiseReceiver> praiseReceivers, long commentCount, List<EmojiReactionGroupDTO> emojiGroups, List<UserProfileResponse> commentPro){
 
-        return PraiseResponseDTO.from(praise, praiseReceivers, commentCount, emojiGroups);
+        return PraiseResponseDTO.from(praise, praiseReceivers, commentCount, emojiGroups,commentPro);
     }
 }

--- a/src/main/java/org/example/hugmeexp/domain/praise/service/PraiseService.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/service/PraiseService.java
@@ -12,6 +12,7 @@ import org.example.hugmeexp.domain.praise.exception.PraiseNotFoundException;
 import org.example.hugmeexp.domain.praise.exception.UserNotFoundInPraiseException;
 import org.example.hugmeexp.domain.praise.mapper.PraiseMapper;
 import org.example.hugmeexp.domain.praise.repository.*;
+import org.example.hugmeexp.domain.user.dto.response.UserProfileResponse;
 import org.example.hugmeexp.domain.user.repository.UserRepository;
 import org.example.hugmeexp.domain.user.entity.User;
 import org.springframework.stereotype.Service;
@@ -46,32 +47,31 @@ public class PraiseService {
     @Transactional
     public PraiseResponseDTO createPraise(PraiseRequestDTO praiseRequestDTO, User sender) {
 
-        try {
-            List<User> receiverUsers = praiseRequestDTO.getReceiverUsername().stream()
-                    .map(username -> userRepository.findByUsername(username)
-                            .orElseThrow(UserNotFoundInPraiseException::new)).toList();
 
-            // DTO -> Entity
-             Praise praise = praiseMapper.toEntity(praiseRequestDTO, sender);
+        List<User> receiverUsers = praiseRequestDTO.getReceiverUsername().stream()
+                .map(username -> userRepository.findByUsername(username)
+                        .orElseThrow(UserNotFoundInPraiseException::new)).toList();
 
-            // DB 에 저장
-            Praise saved = praiseRepository.save(praise);
+        // DTO -> Entity
+         Praise praise = praiseMapper.toEntity(praiseRequestDTO, sender);
 
-            // PraiseReceiver 저장
-            List<PraiseReceiver> praiseReceivers = receiverUsers.stream()
-                    .map(receiver -> PraiseReceiver.builder()
-                            .praise(saved)
-                            .receiver(receiver)
-                            .build())
-                    .toList();
-            praiseReceiverRepository.saveAll(praiseReceivers);
+        // DB 에 저장
+        Praise saved = praiseRepository.save(praise);
 
-            // Entity -> DTO
-            return PraiseResponseDTO.from(saved, praiseReceivers, 0L, null);
-        } catch (UserNotFoundInPraiseException e){
+        // PraiseReceiver 저장
+        List<PraiseReceiver> praiseReceivers = receiverUsers.stream()
+                .map(receiver -> PraiseReceiver.builder()
+                        .praise(saved)
+                        .receiver(receiver)
+                        .build())
+                .toList();
+        praiseReceiverRepository.saveAll(praiseReceivers);
 
-            throw e;
-        }
+        List<UserProfileResponse> commentPro = Collections.emptyList();
+
+        // Entity -> DTO
+        return PraiseResponseDTO.from(saved, praiseReceivers, 0L, null, commentPro);
+
 
     }
 
@@ -119,7 +119,16 @@ public class PraiseService {
 
                     List<PraiseReceiver> receivers = receiverMap.getOrDefault(praise.getId(),List.of());
 
-                    return PraiseResponseDTO.from(praise,receivers,commentCount, emojiGroups);
+                    List<PraiseComment> comments = commentRepository.findByPraise(praise);
+
+                    List<UserProfileResponse> commentProfiles = comments.stream()
+                            .map(c -> {
+                                User user = c.getCommentWriter();
+                                String url = user.getStoredProfileImagePath();
+                                return new UserProfileResponse(url, user.getUsername(), user.getName());
+                            }).toList();
+
+                    return PraiseResponseDTO.from(praise,receivers,commentCount, emojiGroups,commentProfiles);
 
                 }).collect(Collectors.toList());
     }
@@ -174,7 +183,15 @@ public class PraiseService {
 
                     List<PraiseReceiver> receivers = receiverMap.getOrDefault(praise.getId(),List.of());
 
-                    return PraiseResponseDTO.from(praise,receivers,commentCount,emojiGroups);
+                    List<PraiseComment> comments = commentRepository.findByPraise(praise);
+                    List<UserProfileResponse> commentProfiles = comments.stream()
+                            .map(c -> {
+                                User user = c.getCommentWriter();
+                                String url = user.getStoredProfileImagePath();
+                                return new UserProfileResponse(url, user.getUsername(), user.getName());
+                            }).toList();
+
+                    return PraiseResponseDTO.from(praise,receivers,commentCount,emojiGroups,commentProfiles);
                 }).collect(Collectors.toList());
 
     }
@@ -212,7 +229,7 @@ public class PraiseService {
                     // 수신자 리스트
                     List<PraiseReceiver> receivers = receiverMap.getOrDefault(praise.getId(), List.of());
 
-                    return PraiseResponseDTO.from(praise,receivers,commentCount,emojiGroups);
+                    return PraiseResponseDTO.from(praise,receivers,commentCount,emojiGroups,List.of());
 
                 })
 
@@ -273,7 +290,13 @@ public class PraiseService {
                 .map(Praise::getSender)
                 .distinct()
                 .limit(3)
-                .map(RecentPraiseSenderResponseDTO::from)
+                .map(sender -> {
+                    String url = sender.getStoredProfileImagePath();
+                    UserProfileResponse profile = new UserProfileResponse(url, sender.getUsername(), sender.getName());
+
+                    return RecentPraiseSenderResponseDTO.from(sender, List.of(profile));
+
+                })
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
close #118
Update
- 칭찬 게시물 조회 시 프로필 이미지 조회 가능
[![스크린샷 2025-06-26 091026](https://github.com/user-attachments/assets/195b3fe6-3952-443d-a25f-a81dce23d74d)
](url)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 댓글 작성자의 프로필 이미지 경로가 댓글 응답에 포함됩니다.
  * 칭찬 수신자 정보에 이름과 프로필 이미지가 함께 제공됩니다.
  * 칭찬 응답 및 최근 칭찬 보낸 사람 목록에 여러 프로필 이미지가 포함됩니다.

* **개선 사항**
  * 칭찬 관련 응답 데이터에 사용자 프로필 정보가 확장되어 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->