### PR TITLE
infra: WebConfig 요청 메서드, 요청 헤더 수정 및 CORS 허용 포트 추가

### DIFF
--- a/src/main/java/org/example/hugmeexp/global/common/config/WebConfig.java
+++ b/src/main/java/org/example/hugmeexp/global/common/config/WebConfig.java
@@ -11,9 +11,9 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**") // 요청 URL이 /api/** 경로일 것
-                .allowedOrigins("http://localhost:3000") // 요청 출처가 http://localhost:3000일 것
-                .allowedMethods("GET", "POST", "PUT", "DELETE") // HTTP 메서드가 GET, POST, PUT, DELETE 중 하나일 것
-                .allowedHeaders("Authorization") // 요청에 Authorization 헤더를 포함할 수 있음 (꼭 포함해야 한다는 뜻은 아님)
+                .allowedOrigins("http://localhost:3000", "http://localhost:5173") // 요청 출처가 3000, 5173 포트 일 것
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH") // HTTP 메서드가 GET, POST, PUT, DELETE, PATCH 중 하나일 것
+                .allowedHeaders("Authorization", "Content-Type") // Authorization, Content-Type 헤더 허용
                 .allowCredentials(true); // 인증 정보(쿠키 또는 헤더)를 포함하는 요청을 허용
     }
 


### PR DESCRIPTION
- CORS 허용 출처가 3000 포트 뿐이었는데 프론트엔드 개발을 위해 5173 포트를 허용했습니다.
- 허용 HTTP 메서드 중 PATCH가 빠져있었는데 추가했습니다.
- 허용 헤더거 보안 헤더밖에 없었는데 content-type 헤더도 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * CORS 설정이 업데이트되어 `http://localhost:5173`에서의 요청이 허용됩니다.
  * 허용되는 HTTP 메서드에 `PATCH`가 추가되었습니다.
  * 허용되는 헤더에 `Content-Type`이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->