### PR TITLE
bugfix: Mission, MissionGroup 테스트 UserProfileResponse 파라미터 버그 수정

### DIFF
--- a/src/test/java/org/example/hugmeexp/domain/missionGroup/controller/MissionGroupControllerTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/missionGroup/controller/MissionGroupControllerTest.java
@@ -81,7 +81,7 @@ class MissionGroupControllerTest {
     void getAllMissionGroups_ShouldReturnList() throws Exception {
         // Given
         UserProfileResponse teacher = new UserProfileResponse(
-                "teacher1", "Teacher One", "");
+                "", "teacher1", "Teacher One");
 
         MissionGroupResponse missionGroupResponse = MissionGroupResponse
                 .builder()
@@ -102,7 +102,7 @@ class MissionGroupControllerTest {
     @DisplayName("미션 그룹 생성 - 성공")
     void createMissionGroup_ShouldReturnCreated() throws Exception {
         UserProfileResponse teacher = new UserProfileResponse(
-                "teacher1", "Teacher One", "");
+                "", "teacher1", "Teacher One");
 
         // Given
         MissionGroupRequest request = MissionGroupRequest
@@ -132,7 +132,7 @@ class MissionGroupControllerTest {
     @DisplayName("ID로 미션 그룹 조회 - 성공")
     void getMissionGroupById_ShouldReturnOk() throws Exception {
         UserProfileResponse teacher = new UserProfileResponse(
-                "teacher1", "Teacher One", "");
+                "", "teacher1", "Teacher One");
 
         // Given
         MissionGroupResponse response = MissionGroupResponse
@@ -172,7 +172,7 @@ class MissionGroupControllerTest {
     @DisplayName("미션 그룹 수정 - 성공")
     void updateMissionGroup_ShouldReturnOk() throws Exception {
         UserProfileResponse teacher = new UserProfileResponse(
-                "teacher2", "teacher2", "");
+                "", "teacher2", "teacher2");
         // Given
         MissionGroupRequest request = MissionGroupRequest
                 .builder()

--- a/src/test/java/org/example/hugmeexp/domain/missionGroup/service/MissionGroupServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/missionGroup/service/MissionGroupServiceTest.java
@@ -66,9 +66,9 @@ class MissionGroupServiceTest {
     @DisplayName("모든 미션 그룹을 조회한다 - 성공")
     void getAllMissionGroups() {
         UserProfileResponse teacher1 = new UserProfileResponse(
-                "teacher1", "Teacher One", "");
+                "", "teacher1", "Teacher One");
         UserProfileResponse teacher2 = new UserProfileResponse(
-                "teacher2", "Teacher Two", "");
+                "", "teacher2", "Teacher Two");
         // Given
         MissionGroup group1 = mock(MissionGroup.class);
         MissionGroup group2 = mock(MissionGroup.class);
@@ -103,7 +103,7 @@ class MissionGroupServiceTest {
     void createMissionGroup() {
         // Given
         UserProfileResponse teacher = new UserProfileResponse(
-                "teacher1", "teacher1", "");
+                "", "teacher1", "teacher1");
 
         User user1 = User.createUser("teacher1", "password", "Teacher One", "1234");
 
@@ -140,7 +140,7 @@ class MissionGroupServiceTest {
     void getMissionById_found() {
         // Given
         UserProfileResponse teacher = new UserProfileResponse(
-                "teacher1", "Teacher One", "");
+                "", "teacher1", "Teacher One");
 
         Long id = 1L;
         MissionGroup group = mock(MissionGroup.class);
@@ -180,7 +180,7 @@ class MissionGroupServiceTest {
     @DisplayName("미션 그룹을 업데이트한다 - 성공")
     void updateMissionGroup_success() {
         UserProfileResponse teacherResponse = new UserProfileResponse(
-                "teacher", "teacher", "");
+                "", "teacher", "teacher");
 
         Long id = 1L;
         // Given


### PR DESCRIPTION
커밋 메시지를 잘못 남겼네요.
new UserProfileResponse 파라미터 순서를 잘못 넣은 게 있어서 수정하였습니다.

close #122 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 여러 테스트에서 사용자 프로필 응답 객체의 생성 방식이 변경되었습니다.  
  * 기존에는 사용자명이 첫 번째 인자였으나, 이제 빈 문자열이 첫 번째 인자로 들어가고 사용자명은 두 번째 인자로 이동했습니다.  
  * 테스트 로직에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->