### PR TITLE
feat: 내 미션 그룹 목록 조회 기능 추가

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/missionGroup/controller/MissionGroupController.java
+++ b/src/main/java/org/example/hugmeexp/domain/missionGroup/controller/MissionGroupController.java
@@ -6,6 +6,7 @@ import org.example.hugmeexp.domain.mission.dto.response.UserMissionResponse;
 import org.example.hugmeexp.domain.mission.service.MissionService;
 import org.example.hugmeexp.domain.missionGroup.dto.request.MissionGroupRequest;
 import org.example.hugmeexp.domain.missionGroup.dto.response.MissionGroupResponse;
+import org.example.hugmeexp.domain.missionGroup.dto.response.UserMissionGroupResponse;
 import org.example.hugmeexp.domain.missionGroup.service.MissionGroupService;
 import org.example.hugmeexp.global.common.response.Response;
 import org.springframework.http.HttpStatus;
@@ -26,6 +27,12 @@ public class MissionGroupController {
     @GetMapping
     public ResponseEntity<Response<?>> getMissionGroups() {
         List<MissionGroupResponse> missionGroups = missionGroupService.getAllMissionGroups();
+        return ResponseEntity.ok().body(Response.builder().data(missionGroups).message("미션 그룹 목록을 성공적으로 가져왔습니다.").build());
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<Response<?>> getMyMissionGroups(@AuthenticationPrincipal UserDetails user) {
+        List<UserMissionGroupResponse> missionGroups = missionGroupService.getMyMissionGroups(user.getUsername());
         return ResponseEntity.ok().body(Response.builder().data(missionGroups).message("미션 그룹 목록을 성공적으로 가져왔습니다.").build());
     }
 

--- a/src/main/java/org/example/hugmeexp/domain/missionGroup/mapper/UserMissionGroupMapper.java
+++ b/src/main/java/org/example/hugmeexp/domain/missionGroup/mapper/UserMissionGroupMapper.java
@@ -1,0 +1,19 @@
+package org.example.hugmeexp.domain.missionGroup.mapper;
+
+import org.example.hugmeexp.domain.missionGroup.dto.response.UserMissionGroupResponse;
+import org.example.hugmeexp.domain.missionGroup.entity.UserMissionGroup;
+import org.example.hugmeexp.domain.user.mapper.ProfileImageMapper;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring",
+uses = {MissionGroupMapper.class})
+public interface UserMissionGroupMapper {
+    @Mappings({
+            @Mapping(target = "user", ignore = true),
+    })
+    UserMissionGroupResponse toUserMissionGroupResponse(UserMissionGroup userMissionGroup);
+}

--- a/src/main/java/org/example/hugmeexp/domain/missionGroup/repository/UserMissionGroupRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/missionGroup/repository/UserMissionGroupRepository.java
@@ -6,10 +6,13 @@ import org.example.hugmeexp.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UserMissionGroupRepository extends JpaRepository<UserMissionGroup, Long> {
     Boolean existsByUserAndMissionGroup(User user, MissionGroup missionGroup);
     Optional<UserMissionGroup> findByUserAndMissionGroup(User user, MissionGroup missionGroup);
+
+    List<UserMissionGroup> findByUserId(Long userId);
 }

--- a/src/main/java/org/example/hugmeexp/domain/missionGroup/service/MissionGroupService.java
+++ b/src/main/java/org/example/hugmeexp/domain/missionGroup/service/MissionGroupService.java
@@ -2,6 +2,8 @@ package org.example.hugmeexp.domain.missionGroup.service;
 import org.example.hugmeexp.domain.mission.dto.response.UserMissionResponse;
 import org.example.hugmeexp.domain.missionGroup.dto.request.MissionGroupRequest;
 import org.example.hugmeexp.domain.missionGroup.dto.response.MissionGroupResponse;
+import org.example.hugmeexp.domain.missionGroup.dto.response.UserMissionGroupResponse;
+
 import java.util.List;
 
 public interface MissionGroupService {
@@ -20,4 +22,6 @@ public interface MissionGroupService {
     void removeUserFromMissionGroup(Long userId, Long missionGroupId);
 
     List<UserMissionResponse> findUserMissionByUsernameAndMissionGroup(String username, Long missionGroupId);
+
+    List<UserMissionGroupResponse> getMyMissionGroups(String username);
 }

--- a/src/main/java/org/example/hugmeexp/domain/missionGroup/service/MissionGroupServiceImpl.java
+++ b/src/main/java/org/example/hugmeexp/domain/missionGroup/service/MissionGroupServiceImpl.java
@@ -8,10 +8,12 @@ import org.example.hugmeexp.domain.mission.mapper.UserMissionMapper;
 import org.example.hugmeexp.domain.mission.repository.UserMissionRepository;
 import org.example.hugmeexp.domain.missionGroup.dto.request.MissionGroupRequest;
 import org.example.hugmeexp.domain.missionGroup.dto.response.MissionGroupResponse;
+import org.example.hugmeexp.domain.missionGroup.dto.response.UserMissionGroupResponse;
 import org.example.hugmeexp.domain.missionGroup.entity.MissionGroup;
 import org.example.hugmeexp.domain.missionGroup.entity.UserMissionGroup;
 import org.example.hugmeexp.domain.missionGroup.exception.*;
 import org.example.hugmeexp.domain.missionGroup.mapper.MissionGroupMapper;
+import org.example.hugmeexp.domain.missionGroup.mapper.UserMissionGroupMapper;
 import org.example.hugmeexp.domain.missionGroup.repository.MissionGroupRepository;
 import org.example.hugmeexp.domain.missionGroup.repository.UserMissionGroupRepository;
 import org.example.hugmeexp.domain.user.repository.UserRepository;
@@ -29,6 +31,7 @@ public class MissionGroupServiceImpl implements MissionGroupService {
     private final UserMissionRepository userMissionRepository;
     private final MissionGroupMapper missionGroupMapper;
     private final UserMissionMapper userMissionMapper;
+    private final UserMissionGroupMapper userMissionGroupMapper;
 
     @Override
     public List<MissionGroupResponse> getAllMissionGroups() {
@@ -135,6 +138,18 @@ public class MissionGroupServiceImpl implements MissionGroupService {
         return userMissionRepository.findByUserAndUserMissionGroup(user, userMissionGroup)
                 .stream()
                 .map(userMissionMapper::toUserMissionResponse)
+                .toList();
+    }
+
+    @Override
+    public List<UserMissionGroupResponse> getMyMissionGroups(String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(UserNotFoundException::new);
+
+        List<UserMissionGroup> userMissionGroups = userMissionGroupRepository.findByUserId(user.getId());
+        return userMissionGroups
+                .stream()
+                .map(userMissionGroupMapper::toUserMissionGroupResponse)
                 .toList();
     }
 }


### PR DESCRIPTION
사용자가 자신의 미션 그룹 목록을 조회할 수 있는 API를 추가했습니다.

시간 관계로 현재는 테스트 코드를 생략하였지만 정상 작동 여부 확인했습니다.

![image](https://github.com/user-attachments/assets/752cd62f-82e6-46c9-9b6e-138b76cbe64f)

close #125 