### PR TITLE
feat: 미션 그룹 사용자 목록 조회 API 추가

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/missionGroup/controller/MissionGroupController.java
+++ b/src/main/java/org/example/hugmeexp/domain/missionGroup/controller/MissionGroupController.java
@@ -8,6 +8,7 @@ import org.example.hugmeexp.domain.missionGroup.dto.request.MissionGroupRequest;
 import org.example.hugmeexp.domain.missionGroup.dto.response.MissionGroupResponse;
 import org.example.hugmeexp.domain.missionGroup.dto.response.UserMissionGroupResponse;
 import org.example.hugmeexp.domain.missionGroup.service.MissionGroupService;
+import org.example.hugmeexp.domain.user.dto.response.UserProfileResponse;
 import org.example.hugmeexp.global.common.response.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -63,6 +64,12 @@ public class MissionGroupController {
                 .data(missionService.getMissionsByMissionGroupId(id))
                 .message("미션 그룹 " + id + "의 미션 목록을 가져왔습니다.")
                 .build());
+    }
+
+    @GetMapping("/{missionGroupId}/users")
+    public ResponseEntity<Response<?>> getUsersInMissionGroup(@PathVariable Long missionGroupId) {
+        List<UserProfileResponse> users = missionGroupService.getUsersInMissionGroup(missionGroupId);
+        return ResponseEntity.ok().body(Response.builder().data(users).message("미션 그룹 " + missionGroupId + "의 사용자 목록을 가져왔습니다.").build());
     }
 
     @PostMapping("/{missionGroupId}/users/{userId}")

--- a/src/main/java/org/example/hugmeexp/domain/missionGroup/repository/UserMissionGroupRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/missionGroup/repository/UserMissionGroupRepository.java
@@ -15,4 +15,6 @@ public interface UserMissionGroupRepository extends JpaRepository<UserMissionGro
     Optional<UserMissionGroup> findByUserAndMissionGroup(User user, MissionGroup missionGroup);
 
     List<UserMissionGroup> findByUserId(Long userId);
+
+    List<UserMissionGroup> findAllByMissionGroup(MissionGroup missionGroup);
 }

--- a/src/main/java/org/example/hugmeexp/domain/missionGroup/service/MissionGroupService.java
+++ b/src/main/java/org/example/hugmeexp/domain/missionGroup/service/MissionGroupService.java
@@ -3,6 +3,7 @@ import org.example.hugmeexp.domain.mission.dto.response.UserMissionResponse;
 import org.example.hugmeexp.domain.missionGroup.dto.request.MissionGroupRequest;
 import org.example.hugmeexp.domain.missionGroup.dto.response.MissionGroupResponse;
 import org.example.hugmeexp.domain.missionGroup.dto.response.UserMissionGroupResponse;
+import org.example.hugmeexp.domain.user.dto.response.UserProfileResponse;
 
 import java.util.List;
 
@@ -24,4 +25,6 @@ public interface MissionGroupService {
     List<UserMissionResponse> findUserMissionByUsernameAndMissionGroup(String username, Long missionGroupId);
 
     List<UserMissionGroupResponse> getMyMissionGroups(String username);
+
+    List<UserProfileResponse> getUsersInMissionGroup(Long missionGroupId);
 }

--- a/src/main/java/org/example/hugmeexp/domain/missionGroup/service/MissionGroupServiceImpl.java
+++ b/src/main/java/org/example/hugmeexp/domain/missionGroup/service/MissionGroupServiceImpl.java
@@ -16,6 +16,7 @@ import org.example.hugmeexp.domain.missionGroup.mapper.MissionGroupMapper;
 import org.example.hugmeexp.domain.missionGroup.mapper.UserMissionGroupMapper;
 import org.example.hugmeexp.domain.missionGroup.repository.MissionGroupRepository;
 import org.example.hugmeexp.domain.missionGroup.repository.UserMissionGroupRepository;
+import org.example.hugmeexp.domain.user.dto.response.UserProfileResponse;
 import org.example.hugmeexp.domain.user.repository.UserRepository;
 import org.example.hugmeexp.domain.user.entity.User;
 import org.springframework.stereotype.Service;
@@ -150,6 +151,23 @@ public class MissionGroupServiceImpl implements MissionGroupService {
         return userMissionGroups
                 .stream()
                 .map(userMissionGroupMapper::toUserMissionGroupResponse)
+                .toList();
+    }
+
+    @Override
+    public List<UserProfileResponse> getUsersInMissionGroup(Long missionGroupId) {
+        MissionGroup missionGroup = missionGroupRepository.findById(missionGroupId)
+                .orElseThrow(MissionGroupNotFoundException::new);
+
+        List<UserMissionGroup> userMissionGroups = userMissionGroupRepository.findAllByMissionGroup(missionGroup);
+        return userMissionGroups.stream()
+                .map(UserMissionGroup::getUser)
+                .distinct()
+                .map(user -> new UserProfileResponse(
+                        user.getPublicProfileImageUrl(),
+                        user.getUsername(),
+                        user.getName()
+                ))
                 .toList();
     }
 }


### PR DESCRIPTION
미션 그룹 ID에 따라 해당 그룹의 사용자 목록을 가져오는 API를 추가했습니다.
![image](https://github.com/user-attachments/assets/f4d23ce6-ef92-401c-9800-21789c46757c)

closes #131 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 특정 미션 그룹에 속한 사용자 목록을 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.  
  * 미션 그룹 ID를 통해 해당 그룹의 사용자 프로필 정보를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->