### PR TITLE
feat: 사용자 미션 도전 API 추가

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/mission/controller/MissionController.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/controller/MissionController.java
@@ -71,6 +71,14 @@ public class MissionController {
                 .build());
     }
 
+    @GetMapping("/{missionId}/challenges")
+    public ResponseEntity<Response<?>> getChallenge(@PathVariable Long missionId, @AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(Response.builder()
+                .data(missionService.getUserMission(missionId, userDetails.getUsername()))
+                .message("미션 " + missionId + "에 도전하였습니다.")
+                .build());
+    }
+
     @PostMapping("/{id}/challenges")
     public ResponseEntity<Response<?>> challengeMission(@PathVariable Long id, @AuthenticationPrincipal UserDetails userDetails) {
         return ResponseEntity.status(HttpStatus.CREATED).body(Response.builder()

--- a/src/main/java/org/example/hugmeexp/domain/mission/mapper/UserMissionMapper.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/mapper/UserMissionMapper.java
@@ -4,9 +4,11 @@ import org.example.hugmeexp.domain.mission.dto.response.UserMissionResponse;
 import org.example.hugmeexp.domain.mission.entity.UserMission;
 import org.example.hugmeexp.domain.user.mapper.ProfileImageMapper;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring",
 uses = ProfileImageMapper.class)
 public interface UserMissionMapper {
+    @Mapping(target = "user.profileImage", source = "user.publicProfileImageUrl")
     UserMissionResponse toUserMissionResponse(UserMission userMission);
 }

--- a/src/main/java/org/example/hugmeexp/domain/mission/service/MissionService.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/service/MissionService.java
@@ -6,7 +6,6 @@ import org.example.hugmeexp.domain.mission.dto.response.MissionResponse;
 import org.example.hugmeexp.domain.mission.dto.response.SubmissionResponse;
 import org.example.hugmeexp.domain.mission.dto.response.UserMissionResponse;
 import org.example.hugmeexp.domain.mission.dto.response.UserMissionStateLogResponse;
-import org.example.hugmeexp.domain.mission.entity.UserMissionStateLog;
 import org.example.hugmeexp.domain.mission.enums.UserMissionState;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -41,4 +40,6 @@ public interface MissionService {
     void receiveReward(Long userMissionId, String username);
 
     List<UserMissionStateLogResponse> getAllMissionStateLog(long userId, LocalDate startDate, LocalDate endDate);
+
+    UserMissionResponse getUserMission(Long missionId, String username);
 }

--- a/src/main/java/org/example/hugmeexp/domain/mission/service/MissionServiceImpl.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/service/MissionServiceImpl.java
@@ -233,6 +233,8 @@ public class MissionServiceImpl implements MissionService {
         submission.setOriginalFileName(safeFileName); // 복원될 파일명
 
         userMissionSubmissionRepository.save(submission);
+
+        userMission.setProgress(UserMissionState.IN_FEEDBACK);
         // 파일 전송되기 전에 저장하고 파일 전송이 실패하면 롤백되므로(SubmissionFileUploadException)
         // 고아 파일, 고아 레코드가 남지 않을 것임
 
@@ -314,5 +316,19 @@ public class MissionServiceImpl implements MissionService {
         LocalDateTime endDateTime = endDate.plusDays(1).atStartOfDay();
         return userMissionStateLogRepository.findByUserIdAndCreatedAtBetween(userId, startDateTime, endDateTime)
                 .stream().map(userMissionStateLogMapper::toUserMissionStateLogResponse).collect(Collectors.toList());
+    }
+
+    @Override
+    public UserMissionResponse getUserMission(Long missionId, String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(UserNotFoundException::new);
+
+        Mission mission = missionRepository.findById(missionId)
+                .orElseThrow(MissionNotFoundException::new);
+
+        UserMission userMissions = userMissionRepository.findByUserAndMission(user, mission)
+                .orElseThrow(UserMissionNotFoundException::new);
+
+        return userMissionMapper.toUserMissionResponse(userMissions);
     }
 }


### PR DESCRIPTION
사용자가 특정 미션에 도전할 수 있는 API를 추가했습니다.
미션 ID와 사용자 정보를 기반으로 도전 상태를 반환합니다.

closes #146 