### PR TITLE
fix: init.sql 수정, 도커 환경 JVM UTF-8 강제

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -18,6 +18,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD}
       - REDIS_HOST=redis
       - TZ=Asia/Seoul
+      - JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8
     ports:
       - "8080:8080"
     networks:

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -22,6 +22,7 @@ DROP TABLE IF EXISTS user_quest;
 DROP TABLE IF EXISTS user_mission;
 DROP TABLE IF EXISTS mission_task;
 DROP TABLE IF EXISTS user_mission_group;
+DROP TABLE IF EXISTS bookmark;
 
 DROP TABLE IF EXISTS attendance;
 DROP TABLE IF EXISTS orders;
@@ -33,6 +34,7 @@ DROP TABLE IF EXISTS mission;
 DROP TABLE IF EXISTS mission_group;
 DROP TABLE IF EXISTS product;
 DROP TABLE IF EXISTS product_image;
+
 DROP TABLE IF EXISTS profile_image;
 DROP TABLE IF EXISTS users;
 
@@ -85,7 +87,17 @@ CREATE TABLE users (
                        FOREIGN KEY (profile_image_id) REFERENCES profile_image(id)
 ) ENGINE=InnoDB;
 
--- 이 시점에 users 사용 가능
+CREATE TABLE bookmark (
+                          id BIGINT NOT NULL AUTO_INCREMENT,
+                          user_id BIGINT NOT NULL,
+                          title VARCHAR(255) NOT NULL,
+                          link VARCHAR(255) NOT NULL,
+                          created_at DATETIME NOT NULL,
+                          modified_at DATETIME NOT NULL,
+                          PRIMARY KEY (id),
+                          FOREIGN KEY (user_id) REFERENCES user(id)
+) ENGINE=InnoDB;
+
 
 CREATE TABLE product (
                          is_deleted BIT NOT NULL,
@@ -102,8 +114,6 @@ CREATE TABLE product (
 
 CREATE TABLE attendance (
                             attendance_date DATE NOT NULL,
-                            exp INTEGER NOT NULL,
-                            point INTEGER NOT NULL,
                             created_at DATETIME(6),
                             id BIGINT NOT NULL AUTO_INCREMENT,
                             modified_at DATETIME(6),
@@ -311,12 +321,15 @@ CREATE TABLE comment_emoji_reaction (
 -- 공부 일지
 
 CREATE TABLE study_diary (
+                             is_created BIT NOT NULL,
+                             like_count INTEGER NOT NULL,
                              created_at DATETIME(6),
-                             id BIGINT NOT NULL AUTO_INCREMENT,
                              modified_at DATETIME(6),
-                             user_id BIGINT NOT NULL,
-                             content TEXT,
-                             PRIMARY KEY (id),
+                             studydiary_id BIGINT NOT NULL AUTO_INCREMENT,
+                             user_id BIGINT,
+                             content VARCHAR(255),
+                             title VARCHAR(255),
+                             PRIMARY KEY (studydiary_id),
                              FOREIGN KEY (user_id) REFERENCES users(id)
 ) ENGINE=InnoDB;
 
@@ -328,7 +341,7 @@ CREATE TABLE study_diary_comment (
                                      user_id BIGINT,
                                      content VARCHAR(255),
                                      PRIMARY KEY (studydiary_comment_id),
-                                     FOREIGN KEY (studydiary_id) REFERENCES study_diary(id),
+                                     FOREIGN KEY (studydiary_id) REFERENCES study_diary(studydiary_id),
                                      FOREIGN KEY (user_id) REFERENCES users(id)
 ) ENGINE=InnoDB;
 
@@ -339,9 +352,10 @@ CREATE TABLE study_diary_like (
                                   studydiary_like_id BIGINT NOT NULL AUTO_INCREMENT,
                                   user_id BIGINT,
                                   PRIMARY KEY (studydiary_like_id),
-                                  FOREIGN KEY (studydiary_id) REFERENCES study_diary(id),
+                                  FOREIGN KEY (studydiary_id) REFERENCES study_diary(studydiary_id),
                                   FOREIGN KEY (user_id) REFERENCES users(id)
 ) ENGINE=InnoDB;
+
 
 CREATE TABLE orders (
                         created_at DATETIME(6),

--- a/src/main/java/org/example/hugmeexp/domain/user/entity/User.java
+++ b/src/main/java/org/example/hugmeexp/domain/user/entity/User.java
@@ -166,10 +166,6 @@ public class User extends BaseEntity {
 
         String fullPath = internalPath + uuid + ext;
 
-        // "/application" 제거
-//        if (fullPath.startsWith("/application")) {
-//            return fullPath.substring("/application".length());
-//        }
         String userDir = System.getProperty("user.dir");
         if(fullPath.startsWith(userDir)) {
             return fullPath.substring(userDir.length());

--- a/src/main/java/org/example/hugmeexp/global/common/config/WebConfig.java
+++ b/src/main/java/org/example/hugmeexp/global/common/config/WebConfig.java
@@ -1,7 +1,12 @@
 package org.example.hugmeexp.global.common.config;
 
+import jakarta.servlet.Filter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.web.filter.CharacterEncodingFilter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -25,13 +30,8 @@ public class WebConfig implements WebMvcConfigurer {
         String userDir = System.getProperty("user.dir");
 
         String prefix;
-        if (os.contains("win")) {
-            prefix = "file:///" + userDir.replace("\\", "/") + "/";
-        } else {
-            prefix = "file:" + userDir + "/";
-        }
-
-        log.info("Resolved resource prefix: {}", prefix);
+        if (os.contains("win")) prefix = "file:///" + userDir.replace("\\", "/") + "/";
+        else prefix = "file:" + userDir + "/";
 
         registry.addResourceHandler("/profile-images/**")
                 .addResourceLocations(prefix + "profile-images/");


### PR DESCRIPTION
디스코드에서 나눴던 init.sql을 수정했습니다.

도커 환경에서 구동되는 JVM의 인코딩 옵션을 UTF-8로 설정해서 한글깨짐을 방지하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 북마크 정보를 저장하는 새로운 테이블이 추가되었습니다.

* **기능 개선**
  * 출석 테이블에서 일부 불필요한 컬럼이 제거되었습니다.
  * 학습 일지 테이블에 새로운 컬럼이 추가되고, 기존 컬럼 일부가 변경되었습니다.
  * 학습 일지 관련 댓글 및 좋아요 테이블의 외래키 참조가 수정되었습니다.

* **환경 설정**
  * 컨테이너 환경에서 Java 파일 인코딩이 UTF-8로 명시적으로 설정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->