### PR TITLE
Feature/#146 유저 미션 API에 빠진 API 추가

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/mission/controller/ChallengeController.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/controller/ChallengeController.java
@@ -8,6 +8,8 @@ import org.example.hugmeexp.domain.mission.service.MissionService;
 import org.example.hugmeexp.global.common.response.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -22,6 +24,22 @@ public class ChallengeController {
         missionService.changeUserMissionState(challengeId, newProgress);
         return ResponseEntity.ok(Response.builder()
                 .message("챌린지 상태가 성공적으로 업데이트되었습니다.")
+                .build());
+    }
+
+    @GetMapping()
+    public ResponseEntity<Response<?>> getAllChallenges(@AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.ok(Response.builder()
+                .data(missionService.getAllUserMissionsByTeacher(userDetails.getUsername()))
+                .message("모든 챌린지를 성공적으로 가져왔습니다.")
+                .build());
+    }
+
+    @GetMapping("/{challengeId}")
+    public ResponseEntity<Response<?>> getChallengeById(@PathVariable Long challengeId) {
+        return ResponseEntity.ok(Response.builder()
+                .data(missionService.getUserMissionByChallengeId(challengeId))
+                .message("챌린지 " + challengeId + "를 성공적으로 가져왔습니다.")
                 .build());
     }
 

--- a/src/main/java/org/example/hugmeexp/domain/mission/controller/MissionController.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/controller/MissionController.java
@@ -71,6 +71,14 @@ public class MissionController {
                 .build());
     }
 
+    @GetMapping("/{missionId}/challenges")
+    public ResponseEntity<Response<?>> getChallenge(@PathVariable Long missionId, @AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(Response.builder()
+                .data(missionService.getUserMission(missionId, userDetails.getUsername()))
+                .message("미션 " + missionId + "에 도전하였습니다.")
+                .build());
+    }
+
     @PostMapping("/{id}/challenges")
     public ResponseEntity<Response<?>> challengeMission(@PathVariable Long id, @AuthenticationPrincipal UserDetails userDetails) {
         return ResponseEntity.status(HttpStatus.CREATED).body(Response.builder()

--- a/src/main/java/org/example/hugmeexp/domain/mission/controller/MissionController.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/controller/MissionController.java
@@ -73,7 +73,7 @@ public class MissionController {
 
     @GetMapping("/{missionId}/challenges")
     public ResponseEntity<Response<?>> getChallenge(@PathVariable Long missionId, @AuthenticationPrincipal UserDetails userDetails) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(Response.builder()
+        return ResponseEntity.status(HttpStatus.OK).body(Response.builder()
                 .data(missionService.getUserMission(missionId, userDetails.getUsername()))
                 .message("미션 " + missionId + "에 도전하였습니다.")
                 .build());

--- a/src/main/java/org/example/hugmeexp/domain/mission/mapper/UserMissionMapper.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/mapper/UserMissionMapper.java
@@ -4,9 +4,11 @@ import org.example.hugmeexp.domain.mission.dto.response.UserMissionResponse;
 import org.example.hugmeexp.domain.mission.entity.UserMission;
 import org.example.hugmeexp.domain.user.mapper.ProfileImageMapper;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring",
 uses = ProfileImageMapper.class)
 public interface UserMissionMapper {
+    @Mapping(target = "user.profileImage", source = "user.publicProfileImageUrl")
     UserMissionResponse toUserMissionResponse(UserMission userMission);
 }

--- a/src/main/java/org/example/hugmeexp/domain/mission/mapper/UserMissionSubmissionMapper.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/mapper/UserMissionSubmissionMapper.java
@@ -15,5 +15,6 @@ public interface UserMissionSubmissionMapper {
     @Mapping(target = "feedback", ignore = true)
     Submission toEntity(SubmissionUploadRequest submissionUploadRequest);
 
+    @Mapping(target = "userMission", ignore = true)
     SubmissionResponse toSubmissionResponse(Submission submission);
 }

--- a/src/main/java/org/example/hugmeexp/domain/mission/repository/UserMissionRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/repository/UserMissionRepository.java
@@ -16,4 +16,6 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
     boolean existsUserMissionByUserAndMission(User user, Mission mission);
 
     Optional<UserMission> findByUserAndMission(User user, Mission mission);
+
+    List<UserMission> findAllByMission_MissionGroup_Teacher(User missionMissionGroupTeacher);
 }

--- a/src/main/java/org/example/hugmeexp/domain/mission/service/MissionService.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/service/MissionService.java
@@ -42,4 +42,8 @@ public interface MissionService {
     List<UserMissionStateLogResponse> getAllMissionStateLog(long userId, LocalDate startDate, LocalDate endDate);
 
     UserMissionResponse getUserMission(Long missionId, String username);
+
+    List<UserMissionResponse> getAllUserMissionsByTeacher(String username);
+
+    UserMissionResponse getUserMissionByChallengeId(Long challengeId);
 }

--- a/src/main/java/org/example/hugmeexp/domain/mission/service/MissionService.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/service/MissionService.java
@@ -6,7 +6,6 @@ import org.example.hugmeexp.domain.mission.dto.response.MissionResponse;
 import org.example.hugmeexp.domain.mission.dto.response.SubmissionResponse;
 import org.example.hugmeexp.domain.mission.dto.response.UserMissionResponse;
 import org.example.hugmeexp.domain.mission.dto.response.UserMissionStateLogResponse;
-import org.example.hugmeexp.domain.mission.entity.UserMissionStateLog;
 import org.example.hugmeexp.domain.mission.enums.UserMissionState;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -41,4 +40,6 @@ public interface MissionService {
     void receiveReward(Long userMissionId, String username);
 
     List<UserMissionStateLogResponse> getAllMissionStateLog(long userId, LocalDate startDate, LocalDate endDate);
+
+    UserMissionResponse getUserMission(Long missionId, String username);
 }

--- a/src/main/java/org/example/hugmeexp/domain/mission/service/MissionServiceImpl.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/service/MissionServiceImpl.java
@@ -331,4 +331,22 @@ public class MissionServiceImpl implements MissionService {
 
         return userMissionMapper.toUserMissionResponse(userMissions);
     }
+
+    @Override
+    public List<UserMissionResponse> getAllUserMissionsByTeacher(String username) {
+        User teacher = userRepository.findByUsername(username)
+                .orElseThrow(UserNotFoundException::new);
+        List<UserMission> userMissions = userMissionRepository.findAllByMission_MissionGroup_Teacher(teacher);
+
+        return userMissions
+                .stream().map(userMissionMapper::toUserMissionResponse).collect(Collectors.toList());
+    }
+
+    @Override
+    public UserMissionResponse getUserMissionByChallengeId(Long challengeId) {
+        UserMission userMission = userMissionRepository.findById(challengeId)
+                .orElseThrow(UserMissionNotFoundException::new);
+
+        return userMissionMapper.toUserMissionResponse(userMission);
+    }
 }

--- a/src/main/java/org/example/hugmeexp/domain/mission/service/MissionServiceImpl.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/service/MissionServiceImpl.java
@@ -233,6 +233,8 @@ public class MissionServiceImpl implements MissionService {
         submission.setOriginalFileName(safeFileName); // 복원될 파일명
 
         userMissionSubmissionRepository.save(submission);
+
+        userMission.setProgress(UserMissionState.IN_FEEDBACK);
         // 파일 전송되기 전에 저장하고 파일 전송이 실패하면 롤백되므로(SubmissionFileUploadException)
         // 고아 파일, 고아 레코드가 남지 않을 것임
 
@@ -314,5 +316,19 @@ public class MissionServiceImpl implements MissionService {
         LocalDateTime endDateTime = endDate.plusDays(1).atStartOfDay();
         return userMissionStateLogRepository.findByUserIdAndCreatedAtBetween(userId, startDateTime, endDateTime)
                 .stream().map(userMissionStateLogMapper::toUserMissionStateLogResponse).collect(Collectors.toList());
+    }
+
+    @Override
+    public UserMissionResponse getUserMission(Long missionId, String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(UserNotFoundException::new);
+
+        Mission mission = missionRepository.findById(missionId)
+                .orElseThrow(MissionNotFoundException::new);
+
+        UserMission userMissions = userMissionRepository.findByUserAndMission(user, mission)
+                .orElseThrow(UserMissionNotFoundException::new);
+
+        return userMissionMapper.toUserMissionResponse(userMissions);
     }
 }


### PR DESCRIPTION
유저 미션 API에 빠진 API 추가되었습니다.

closes #146 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 교사 계정으로 로그인 시, 본인과 연관된 모든 챌린지 목록을 조회할 수 있는 엔드포인트가 추가되었습니다.
  * 특정 챌린지 ID로 챌린지 상세 정보를 조회할 수 있는 기능이 추가되었습니다.
  * 미션 ID로 해당 미션에 대한 챌린지 정보를 확인할 수 있는 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 챌린지 제출 시, 제출 직후 미션 진행 상태가 즉시 '피드백 대기'로 반영되도록 개선되었습니다.

* **기타**
  * 사용자 프로필 이미지가 올바르게 매핑되도록 응답 데이터가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->