### PR TITLE
출석체크 도메인 불필요한 테스트 제거

### DIFF
--- a/src/test/java/org/example/hugmeexp/domain/attendance/service/AttendanceServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/attendance/service/AttendanceServiceTest.java
@@ -268,20 +268,6 @@ class AttendanceServiceTest {
                     () -> attendanceService.checkAttendance(username));
         }
 
-        @Test @DisplayName("낙관적 락, 동시성 충돌 시 → AttendanceAlreadyCheckedException")
-        void optimisticLockingConflict() {
-            User user = mock(User.class);
-            when(userRepository.findByUsername(username)).thenReturn(Optional.of(user));
-            when(attendanceRepository.existsByUser_UsernameAndAttendanceDate(eq(username), any(LocalDate.class)))
-                    .thenReturn(false);
-            // save()에서 OptimisticLockException 던지도록 모킹
-            when(attendanceRepository.save(any(Attendance.class)))
-                    .thenThrow(new ObjectOptimisticLockingFailureException(Attendance.class, 1L));
-
-            assertThrows(AttendanceAlreadyCheckedException.class,
-                    () -> attendanceService.checkAttendance(username));
-        }
-
         @Test @DisplayName("정상 처리 → exp, point 증가 및 응답 반환")
         void success() {
             User user = mock(User.class);


### PR DESCRIPTION
### 주요 변경점
- 출첵 서비스 단에서 낙관적 락을 삭제하고 출첸 엔티티에서 복합키로 동시성 문제를 해결하였습니다. 
- 따라서 필요 없어지고 빌드 에러를 일으키는 낙관적 락 테스트 코드를 제거합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 출석 체크 시 낙관적 락 충돌을 다루는 테스트가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->