### PR TITLE
츨석체크 도메인 swagger 추가

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/attendance/controller/AttendanceController.java
+++ b/src/main/java/org/example/hugmeexp/domain/attendance/controller/AttendanceController.java
@@ -1,5 +1,9 @@
 package org.example.hugmeexp.domain.attendance.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.hugmeexp.domain.attendance.dto.AttendanceCheckResponse;
@@ -15,19 +19,23 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.util.List;
 
+@Tag(name = "Attendance", description = "출석체크 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/attendance")
 @Slf4j
 public class AttendanceController {
 
+
+
     private final AttendanceService attendanceService;
 
-    /**
-     * 출석 상태 조회
-     * - 사용자 ID를 통해 해당 사용자의 출석 상태를 조회
-     * - 연속 출석 일수와 오늘 날짜도 함께 반환
-     */
+    @Operation(summary = "출석 상태 조회", description = "일주일 출석 여부/연속출석/오늘 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
     @GetMapping("/status")
     public ResponseEntity<Response<AttendanceStatusResponse>> getAttendanceStatus(
             @AuthenticationPrincipal UserDetails userDetails) {
@@ -48,11 +56,13 @@ public class AttendanceController {
     }
 
 
-    /**
-     * 출석 체크
-     * - 사용자 ID와 출석 체크 요청 데이터를 통해 출석 체크를 수행
-     * - 성공 여부, 연속 출석 일수, 오늘의 출석 상태 등을 반환
-     */
+    @Operation(summary = "출석 체크하기", description = "오늘 출석 체크 (경험치와 구름조각 지급)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "출석체크 성공"),
+            @ApiResponse(responseCode = "400", description = "이미 출석했거나 잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
     @PostMapping("/check")
     public ResponseEntity<Response<AttendanceCheckResponse>> checkAttendance(
             @AuthenticationPrincipal UserDetails userDetails){
@@ -65,10 +75,15 @@ public class AttendanceController {
         return ResponseEntity.ok(response);
     }
 
-    /**
-     * 한 유저가 출석한 전체 날짜 조회
-     * 출석한 날짜들을 리스트로 반환
-     */
+    @Operation(
+            summary = "출석 날짜 전체 조회",
+            description = "로그인한 사용자가 출석한 모든 날짜를 yyyy-MM-dd 문자열 리스트로 반환"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
     @GetMapping("/dates")
     public ResponseEntity<Response<List<String>>> getAllDates(
             @AuthenticationPrincipal UserDetails userDetails) {

--- a/src/main/java/org/example/hugmeexp/domain/attendance/dto/AttendanceCheckResponse.java
+++ b/src/main/java/org/example/hugmeexp/domain/attendance/dto/AttendanceCheckResponse.java
@@ -1,5 +1,6 @@
 package org.example.hugmeexp.domain.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,7 +11,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AttendanceCheckResponse {
+
+    @Schema(description = "출석체크 여부 (true: 출석, false: 결석)")
     private boolean attend;
+
+    @Schema(description = "획득한 경험치")
     private int exp;
+
+    @Schema(description = "획득한 구름조각 개수")
     private int point;
 }

--- a/src/main/java/org/example/hugmeexp/domain/attendance/dto/AttendanceStatusResponse.java
+++ b/src/main/java/org/example/hugmeexp/domain/attendance/dto/AttendanceStatusResponse.java
@@ -1,5 +1,6 @@
 package org.example.hugmeexp.domain.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -16,13 +17,16 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AttendanceStatusResponse {
-    // 일요일~토요일 출석 여부 (true: 출석, false: 결석)
+
+    @Schema(description = "출석한 날짜(yyyy-MM-dd) 리스트, (true: 출석, false: 결석)")
     @Size(min=7, max=7)
     private List<Boolean> attendanceStatus;
-    // 연속 출석 일수
+
+    @Schema(description = "연속 출석 일수")
     @Min(0)
     private int continuousDay;
-    // 오늘 날짜
+
+    @Schema(description = "오늘 날짜 (yyyy-MM-dd)")
     @NotNull
     private LocalDate today;
 


### PR DESCRIPTION
- 츨석체크 도메인의 controller, dto 단에  swagger를 추가하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 출석체크 관련 API에 Swagger(OpenAPI) 문서화가 추가되어, 각 엔드포인트와 응답에 대한 설명이 개선되었습니다.
  * 출석 응답 데이터의 각 필드에 대한 설명이 API 문서에 명확하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->