### PR TITLE
refactor: UserMissionMapper에서 ProfileImageMapper 사용 제거

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/mission/mapper/UserMissionMapper.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/mapper/UserMissionMapper.java
@@ -6,8 +6,7 @@ import org.example.hugmeexp.domain.user.mapper.ProfileImageMapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring",
-uses = ProfileImageMapper.class)
+@Mapper(componentModel = "spring")
 public interface UserMissionMapper {
     @Mapping(target = "user.profileImage", source = "user.publicProfileImageUrl")
     UserMissionResponse toUserMissionResponse(UserMission userMission);


### PR DESCRIPTION
ProfileImageMapper의 사용을 제거하여 코드 간결성을 높였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 내부 매퍼 사용 선언을 제거하여 매퍼 설정이 간소화되었습니다.  
  (사용자에게 직접적으로 보이는 기능 변화는 없습니다.)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->