### PR TITLE
refactor: UserMissionMapper에서 ProfileImageMapper 사용 제거

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/mission/mapper/UserMissionMapper.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/mapper/UserMissionMapper.java
@@ -6,8 +6,7 @@ import org.example.hugmeexp.domain.user.mapper.ProfileImageMapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring",
-uses = ProfileImageMapper.class)
+@Mapper(componentModel = "spring")
 public interface UserMissionMapper {
     @Mapping(target = "user.profileImage", source = "user.publicProfileImageUrl")
     UserMissionResponse toUserMissionResponse(UserMission userMission);


### PR DESCRIPTION
ProfileImageMapper의 사용을 제거하여 코드 간결성을 높였습니다.