### PR TITLE
test: TestContainer의 Redis를 사용한 로그인, 로그아웃, 리프레시, 등록 테스트 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    testImplementation 'org.testcontainers:junit-jupiter:1.19.7'
+    testImplementation 'org.testcontainers:testcontainers:1.19.7'
+
     //h2
     runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/test/java/org/example/hugmeexp/global/auth/controller/LoginControllerTest.java
+++ b/src/test/java/org/example/hugmeexp/global/auth/controller/LoginControllerTest.java
@@ -5,19 +5,21 @@ import org.example.hugmeexp.domain.user.service.UserService;
 import org.example.hugmeexp.global.infra.auth.dto.request.LoginRequest;
 import org.example.hugmeexp.global.infra.auth.dto.request.RegisterRequest;
 import org.example.hugmeexp.global.infra.auth.service.CredentialService;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -30,6 +32,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @DisplayName("로그인 컨트롤러 테스트")
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestPropertySource(properties = {
         "jwt.secret=aHR0cHM6Ly9naXRodWIuY29tL3NldW5nd29vay9qd3QtYXBpLXNlcnZlci1zYW1wbGUteW91LWNhbi11c2UtdGhpcy1sb25nLXNlY3JldC1rZXktZm9yLWVuY3J5cHRpb24K",
         "jwt.access-token-expiration=10000",
@@ -48,6 +52,16 @@ class LoginControllerTest {
 
     @Autowired
     private UserService userService;
+
+    @Container
+    static GenericContainer<?> redis = new GenericContainer<>("redis:7.2-alpine")
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.redis.host", redis::getHost);
+        registry.add("spring.redis.port", () -> redis.getMappedPort(6379));
+    }
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/org/example/hugmeexp/global/auth/controller/LogoutControllerTest.java
+++ b/src/test/java/org/example/hugmeexp/global/auth/controller/LogoutControllerTest.java
@@ -9,11 +9,17 @@ import org.example.hugmeexp.global.infra.auth.service.CredentialService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -26,6 +32,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "jwt.access-token-expiration=10000",
         "jwt.refresh-token-expiration=60000"
 })
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class LogoutControllerTest {
 
     @Autowired
@@ -37,6 +45,16 @@ class LogoutControllerTest {
     private final String username = "logoutuser";
     private final String phone = "010-2222-3333";
     private final String password = "logout123!";
+
+    @Container
+    static GenericContainer<?> redis = new GenericContainer<>("redis:7.2-alpine")
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.redis.host", redis::getHost);
+        registry.add("spring.redis.port", () -> redis.getMappedPort(6379));
+    }
 
     @AfterEach
     void tearDown() {

--- a/src/test/java/org/example/hugmeexp/global/auth/controller/RefreshControllerTest.java
+++ b/src/test/java/org/example/hugmeexp/global/auth/controller/RefreshControllerTest.java
@@ -12,13 +12,19 @@ import org.example.hugmeexp.global.infra.auth.service.CredentialService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.http.MediaType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -31,6 +37,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "jwt.access-token-expiration=1000",
         "jwt.refresh-token-expiration=60000"
 })
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RefreshControllerTest {
 
     @Autowired
@@ -43,6 +51,16 @@ class RefreshControllerTest {
     private final String username = "refreshuser";
     private final String phone = "010-3333-4444";
     private final String password = "refresh123!";
+
+    @Container
+    static GenericContainer<?> redis = new GenericContainer<>("redis:7.2-alpine")
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.redis.host", redis::getHost);
+        registry.add("spring.redis.port", () -> redis.getMappedPort(6379));
+    }
 
     @AfterEach
     void tearDown() {

--- a/src/test/java/org/example/hugmeexp/global/auth/controller/RegisterControllerTest.java
+++ b/src/test/java/org/example/hugmeexp/global/auth/controller/RegisterControllerTest.java
@@ -8,13 +8,19 @@ import org.example.hugmeexp.global.infra.auth.service.CredentialService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -27,7 +33,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "jwt.access-token-expiration=10000",
         "jwt.refresh-token-expiration=60000"
 })
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RegisterControllerTest {
+
+    @Container
+    static GenericContainer<?> redis = new GenericContainer<>("redis:7.2-alpine")
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.redis.host", redis::getHost);
+        registry.add("spring.redis.port", () -> redis.getMappedPort(6379));
+    }
 
     @Autowired private MockMvc mockMvc;
     @Autowired private ObjectMapper objectMapper;


### PR DESCRIPTION
TestContainer의 Redis를 사용하여 테스트 환경을 구성하고, 관련 테스트 클래스에 통합했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 테스트 환경에 Testcontainers를 활용한 Redis 컨테이너 통합을 추가하여, 로그인, 로그아웃, 리프레시, 회원가입 컨트롤러 테스트가 실제 Redis 인스턴스에서 실행되도록 개선하였습니다.  
  * 테스트 실행 시 Redis 컨테이너가 자동으로 관리되며, Spring 환경설정이 동적으로 적용됩니다.

* **Chores**
  * Gradle 테스트 의존성에 Testcontainers 관련 라이브러리를 추가하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->