### PR TITLE
fix: 리프레시 토큰 발급 로직 수정

### DIFF
--- a/src/main/java/org/example/hugmeexp/global/infra/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/jwt/JwtTokenProvider.java
@@ -9,7 +9,6 @@ import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.hugmeexp.domain.user.enums.UserRole;
-import org.example.hugmeexp.global.infra.auth.exception.AccessTokenStillValidException;
 import org.example.hugmeexp.global.infra.auth.exception.InvalidAccessTokenException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -179,7 +178,7 @@ public class JwtTokenProvider {
 
             // 액세스 토큰이 여전히 유효하다면 예외를 던짐
             log.warn("Access token is still valid. Rejecting issuing refresh token - accessToken: {}...", accessToken.substring(0, 10));
-            throw new AccessTokenStillValidException();
+//            throw new AccessTokenStillValidException();
         }
         catch (ExpiredJwtException e) {
             // 액세스 토큰의 유효기간이 만료되었다면 pass

--- a/src/main/java/org/example/hugmeexp/global/infra/auth/service/TokenService.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/service/TokenService.java
@@ -83,6 +83,9 @@ public class TokenService
         // 3. 사용자 정보 추출
         String username = jwtTokenProvider.getUsername(refreshToken);
         String role = jwtTokenProvider.getRole(refreshToken);
+        if (!role.startsWith("ROLE_")) {
+            role = "ROLE_" + role;
+        }
 
         // 4. 기존 리프레시 토큰 무효화 처리
         jwtTokenProvider.revokeRefreshToken(refreshToken);


### PR DESCRIPTION
액세스 토큰이 여전히 유효한 경우 리프레시 토큰 발급을 허용하도록 수정했습니다.
또한, 리프레시 시 역할에 'ROLE_' 접두사를 추가하는 로직을 추가했습니다.

closes #189 