### PR TITLE
알림 기능 구현 - 칭찬 받았을 경우

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/notification/controller/NotificationController.java
+++ b/src/main/java/org/example/hugmeexp/domain/notification/controller/NotificationController.java
@@ -1,0 +1,69 @@
+package org.example.hugmeexp.domain.notification.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.hugmeexp.domain.notification.dto.NotificationResponseDTO;
+import org.example.hugmeexp.domain.notification.service.NotificationService;
+import org.example.hugmeexp.domain.user.entity.User;
+import org.example.hugmeexp.global.common.response.Response;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j    // 로깅 어노테이션
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+@Tag(name = "Notifications" , description = "알림 관련 API")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    // 알림 목록 조회
+    @GetMapping
+    public ResponseEntity<Response<List<NotificationResponseDTO>>> getMyNotifications(@AuthenticationPrincipal User user){
+
+        List<NotificationResponseDTO> result =  notificationService.getMyNotifications(user);
+
+        Response<List<NotificationResponseDTO>> response = Response.<List<NotificationResponseDTO>>builder()
+            .message("알림 목록 조회 성공")
+            .data(result)
+            .build();
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    // 알림 읽음 처리
+    @PatchMapping("/{notificationId}/read")
+    public ResponseEntity<Response<Void>> markAsRead(@PathVariable Long notificationId,
+                                                     @AuthenticationPrincipal User user){
+
+        notificationService.markAsRead(notificationId, user);
+
+        Response<Void> response = Response.<Void>builder()
+            .message("알림 읽음 처리 완료")
+            .data(null)
+            .build();
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    // 전체 알림 읽음 처리
+    @PatchMapping("/read-all")
+    public ResponseEntity<Response<Void>> markAllAsRead(@AuthenticationPrincipal User user){
+
+        notificationService.markAllAsRead(user);
+
+        Response<Void> response = Response.<Void>builder()
+            .message("모든 알림 읽음 처리 완료")
+            .data(null)
+            .build();
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+}

--- a/src/main/java/org/example/hugmeexp/domain/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/notification/dto/NotificationResponseDTO.java
@@ -1,0 +1,34 @@
+package org.example.hugmeexp.domain.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.hugmeexp.domain.notification.entity.Notification;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationResponseDTO {
+
+    private Long id;
+    private String type;
+    private String content;
+    private boolean isRead;
+    private LocalDateTime createdAt;
+    private  String category; // 추가: 알림 카테고리
+
+    public static NotificationResponseDTO from(Notification notification) {
+        return NotificationResponseDTO.builder()
+                .id(notification.getId())
+                .type(notification.getType().name())
+                .content(notification.getContent())
+                .isRead(notification.isRead())
+                .createdAt(notification.getCreatedAt())
+                .category(notification.getType().getCategory().name())
+                .build();
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/notification/entity/Notification.java
+++ b/src/main/java/org/example/hugmeexp/domain/notification/entity/Notification.java
@@ -1,0 +1,51 @@
+package org.example.hugmeexp.domain.notification.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.hugmeexp.domain.notification.enums.NotificationType;
+import org.example.hugmeexp.domain.user.entity.User;
+import org.example.hugmeexp.global.entity.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Table(name = "notification")
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 알림 받을 사용자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType type;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private boolean isRead;
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
+
+    public static Notification of(User user, NotificationType type, String content) {
+        return Notification.builder()
+                .user(user)
+                .type(type)
+                .content(content)
+                .isRead(false)
+                .build();
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/notification/enums/NotificationType.java
+++ b/src/main/java/org/example/hugmeexp/domain/notification/enums/NotificationType.java
@@ -1,0 +1,24 @@
+package org.example.hugmeexp.domain.notification.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@AllArgsConstructor
+@ToString
+public enum NotificationType {
+
+    PRAISE_RECEIVED("칭찬을 받았어요", Category.ACTIVITY),
+    DIARY_COMMENT("내 배움일기에 댓글이 달렸어요", Category.ACTIVITY),
+    DIARY_LIKE("내 배움일기에 좋아요가 달렸어요", Category.ACTIVITY),
+    LEVEL_UP("레벨 업 했어요", Category.REWARD),;
+
+    private final String description;
+    private final Category category;
+
+    public enum Category {
+        ACTIVITY,
+        REWARD
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/notification/exception/ForbiddenNotificationAccessException.java
+++ b/src/main/java/org/example/hugmeexp/domain/notification/exception/ForbiddenNotificationAccessException.java
@@ -1,0 +1,10 @@
+package org.example.hugmeexp.domain.notification.exception;
+
+import org.example.hugmeexp.global.common.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+public class ForbiddenNotificationAccessException extends BaseCustomException {
+    public ForbiddenNotificationAccessException() {
+        super(HttpStatus.FORBIDDEN, "본인의 알림만 읽을 수 있습니다.", 403);
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/notification/exception/NotificationNotFoundException.java
+++ b/src/main/java/org/example/hugmeexp/domain/notification/exception/NotificationNotFoundException.java
@@ -1,0 +1,10 @@
+package org.example.hugmeexp.domain.notification.exception;
+
+import org.example.hugmeexp.global.common.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+public class NotificationNotFoundException extends BaseCustomException {
+    public NotificationNotFoundException(){
+        super(HttpStatus.NOT_FOUND,"알림을 찾을 수 없습니다",404);
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,18 @@
+package org.example.hugmeexp.domain.notification.repository;
+
+import org.example.hugmeexp.domain.notification.entity.Notification;
+import org.example.hugmeexp.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    // 특정 사용자의 알림 전체 조회(최신순)
+    List<Notification> findByUserOrderByCreatedAtDesc(User user);
+
+    // 읽지 않은 알림 조회
+    List<Notification> findByUserAndIsReadFalse(User user);
+}

--- a/src/main/java/org/example/hugmeexp/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/example/hugmeexp/domain/notification/service/NotificationService.java
@@ -1,0 +1,96 @@
+package org.example.hugmeexp.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.hugmeexp.domain.notification.dto.NotificationResponseDTO;
+import org.example.hugmeexp.domain.notification.entity.Notification;
+import org.example.hugmeexp.domain.notification.enums.NotificationType;
+import org.example.hugmeexp.domain.notification.exception.ForbiddenNotificationAccessException;
+import org.example.hugmeexp.domain.notification.exception.NotificationNotFoundException;
+import org.example.hugmeexp.domain.notification.repository.NotificationRepository;
+import org.example.hugmeexp.domain.user.entity.User;
+import org.example.hugmeexp.global.common.sse.SseService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final SseService sseService;
+
+    // 칭찬을 받았을 때 알림을 생성하고 SSE로 전송
+    @Transactional
+    public void sendPraiseNotification(User user){
+        createAndSend(user, NotificationType.PRAISE_RECEIVED, NotificationType.PRAISE_RECEIVED.getDescription());
+    }
+
+    // 배움일기에 댓글이 달렸을 때 알림을 생성하고 SSE로 전송
+    @Transactional
+    public void sendDiaryCommentNotification(User user, String diaryTitle) {
+        String title = diaryTitle == null ? "새 배움일기" : diaryTitle;
+        String message = title + "에 댓글이 달렸어요";
+        createAndSend(user, NotificationType.DIARY_COMMENT, message);
+    }
+
+    // 배움일기에 좋아요가 달렸을 때 알림을 생성하고 SSE로 전송
+    @Transactional
+    public void sendDiaryLikeNotification(User user, String diaryTitle) {
+        String title = diaryTitle == null ? "새 배움일기" : diaryTitle;
+        String message = title + "에 좋아요가 달렸어요";
+        createAndSend(user, NotificationType.DIARY_LIKE, message);
+    }
+
+    // 레벨 업 했을 때 알림을 생성하고 SSE로 전송
+    @Transactional
+    public void sendLevelUpNotification(User user, int level) {
+        String message = "레벨 " + level + "로 업그레이드 되었어요!";
+        createAndSend(user, NotificationType.LEVEL_UP, message);
+    }
+
+    private void createAndSend(User user, NotificationType type, String message) {
+        Notification notification = Notification.of(user, type, message);
+        notificationRepository.save(notification);
+        sseService.sendNotification(user.getId(), notification);    // 실시간 전송
+
+    }
+
+    // 내 알림 목록 조회
+    @Transactional(readOnly = true)
+    public List<NotificationResponseDTO> getMyNotifications(User user) {
+        return notificationRepository.findByUserOrderByCreatedAtDesc(user)
+                .stream()
+                .map(NotificationResponseDTO::from)
+                .toList();
+    }
+
+    // 알림 읽음 처리
+    @Transactional
+    public void markAsRead(Long notificationId, User user) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new NotificationNotFoundException());
+        if (!notification.getUser().getId().equals(user.getId())) {
+            throw new ForbiddenNotificationAccessException();
+        }
+        notification.markAsRead();
+    }
+
+    // 모든 알림 읽음 처리
+    @Transactional
+    public void markAllAsRead(User user) {
+        List<Notification> notifications = notificationRepository.findByUserAndIsReadFalse(user);
+        if (notifications.isEmpty()) {
+            return; // 읽지 않은 알림이 없으면 그냥 리턴
+        }
+        for (Notification notification : notifications) {
+            if (!notification.getUser().getId().equals(user.getId())) {
+                throw new ForbiddenNotificationAccessException();
+            }
+            notification.markAsRead();
+        }
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/praise/service/PraiseService.java
+++ b/src/main/java/org/example/hugmeexp/domain/praise/service/PraiseService.java
@@ -2,6 +2,7 @@ package org.example.hugmeexp.domain.praise.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.hugmeexp.domain.notification.service.NotificationService;
 import org.example.hugmeexp.domain.praise.dto.*;
 import org.example.hugmeexp.domain.praise.entity.*;
 import org.example.hugmeexp.domain.praise.enums.PraiseType;
@@ -38,6 +39,7 @@ public class PraiseService {
     private final PraiseReceiverRepository praiseReceiverRepository;
     private final CommentEmojiReactionRepository commentEmojiReactionRepository;
     private final CommentService commentService;
+    private final NotificationService notificationService;
 
 
     /* 칭찬 생성 */
@@ -63,6 +65,13 @@ public class PraiseService {
                         .build())
                 .toList();
         praiseReceiverRepository.saveAll(praiseReceivers);
+
+        // 알림 전송 시 자기 자신에게 보낸 칭찬은 제외
+        for (User receiver : receiverUsers) {
+            if (!receiver.getId().equals(sender.getId())) {
+                notificationService.sendPraiseNotification(receiver);
+            }
+        }
 
         List<UserProfileResponse> commentPro = Collections.emptyList();
         List<EmojiReactionGroupDTO> emojis = Collections.emptyList();

--- a/src/main/java/org/example/hugmeexp/global/common/sse/EmitterRepository.java
+++ b/src/main/java/org/example/hugmeexp/global/common/sse/EmitterRepository.java
@@ -1,0 +1,44 @@
+package org.example.hugmeexp.global.common.sse;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+@RequiredArgsConstructor
+public class EmitterRepository {
+
+    // 사용자 Id 기준으로 emitter를 저장하는 맵
+    private final Map<Long, SseEmitter> emitterMap = new ConcurrentHashMap<>();
+
+    // 사용자 id 로 Emitter 저장하기
+    public void save(Long userId, SseEmitter emitter) {
+        emitterMap.put(userId, emitter);
+    }
+
+    // 등록된 Emitter 조회
+    public SseEmitter get(Long userId) {
+        return emitterMap.get(userId);
+    }
+
+    // 연결 해제 시 Emitter 삭제
+    // 예를 들어 클라이언트가 연결을 끊었을 때 호출
+    // 또는 서버에서 해당 유저의 SSE 연결을 종료할 때 사용
+    public void delete(Long userId) {
+        emitterMap.remove(userId);
+    }
+
+    // 유저 id와 연결된 Emitter가 존재하는지 확인
+    public boolean exists(Long userId) {
+        return emitterMap.containsKey(userId);
+    }
+
+    // 전체 연결 초기화
+    // 테스트나 서버 재시작 시 모든 Emitter를 초기화할 때 사용
+    public void clear() {
+        emitterMap.clear();
+    }
+}

--- a/src/main/java/org/example/hugmeexp/global/common/sse/SseController.java
+++ b/src/main/java/org/example/hugmeexp/global/common/sse/SseController.java
@@ -1,0 +1,29 @@
+package org.example.hugmeexp.global.common.sse;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.hugmeexp.domain.notification.service.NotificationService;
+import org.example.hugmeexp.domain.user.entity.User;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Slf4j    // 로깅 어노테이션
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
+@Tag(name = "Notifications" , description = "알림 관련 API")
+public class SseController {
+
+    private final SseService sseService;
+    private final NotificationService notificationService;
+
+    // 클라이언트에서 EventSource로 구독 요청
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@AuthenticationPrincipal User user) {
+        return sseService.subscribe(user.getId());
+    }
+
+}

--- a/src/main/java/org/example/hugmeexp/global/common/sse/SseService.java
+++ b/src/main/java/org/example/hugmeexp/global/common/sse/SseService.java
@@ -1,0 +1,79 @@
+package org.example.hugmeexp.global.common.sse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.hugmeexp.domain.notification.entity.Notification;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SseService {
+
+    private final EmitterRepository emitterRepository;
+    private static final Long DEFAULT_TIMEOUT = 30 * 60 * 1000L; // 30분
+
+    /** SSE 구독 - 클라이언트가 서버에 연결 요청할 때 호출 됨
+        * SSE mitter를 생성하고, 해당 Emitter를 저장소에 등록, 타임 아웃 설정
+        * @param userId 구독할 사용자 ID
+     */
+    public SseEmitter subscribe(Long userId) {
+        // 기본 timeout 설정 : 30분
+        SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
+        emitterRepository.save(userId, emitter);
+
+        // 연결 완료 및 콜백 등록
+        // Emitter가 완료( 모든 데이터가 성공적으로 전송한 상태 ) emitter 삭제
+        emitter.onCompletion(() -> {
+            log.info("SSE connection completed for userId: {}", userId);
+            emitterRepository.delete(userId);
+        });
+        // Emitter가 타임아웃( 지정된 시간 동안 어떠한 이벤트도 전송되지 않은 상태 ) emitter 삭제
+        emitter.onTimeout(() -> {
+            log.info("SSE connection timed out for userId: {}", userId);
+            emitterRepository.delete(userId);
+        });
+        // Emitter가 에러 발생 시 emitter 삭제
+        emitter.onError(e -> {
+            log.error("SSE connection error for userId: {}", userId, e);
+            emitterRepository.delete(userId);
+        });
+
+        // 연결 확인 용 더미 이벤트 전송
+        try{
+            emitter.send(SseEmitter.event()
+                    .name("connected")
+                    .data("SSE connection established for userId: " + userId));
+        } catch (IOException e){
+            log.warn("SSE connection error for userId: {}", userId, e);
+        }
+
+        return emitter;
+    }
+
+    /** SSE 알림 전송 - 특정 사용자에게 알림을 전송
+        * @param userId 알림을 받을 사용자 ID
+        * @param notification 전송할 알림 객체
+     */
+    public void sendNotification(Long userId, Notification notification) {
+        SseEmitter emitter = emitterRepository.get(userId);
+        if (emitter != null) {
+            try{
+                // 알림 이벤트 전송
+                emitter.send(SseEmitter.event()
+                        .name("notification")
+                        .data(notification));
+                log.info("SSE notification sent to userId: {}", userId, notification.getContent());
+            } catch (IOException e) {
+                log.error("Failed to send SSE notification to userId: {}", userId, e);
+                // 전송 실패 시 Emitter 삭제
+                emitterRepository.delete(userId);
+            }
+        } else {
+            log.warn("No SSE connection found for userId: {}", userId);
+        }
+    }
+}

--- a/src/main/java/org/example/hugmeexp/global/common/sse/SseService.java
+++ b/src/main/java/org/example/hugmeexp/global/common/sse/SseService.java
@@ -66,7 +66,7 @@ public class SseService {
                 emitter.send(SseEmitter.event()
                         .name("notification")
                         .data(notification));
-                log.info("SSE notification sent to userId: {}", userId, notification.getContent());
+                log.info("SSE notification sent to userId: {}, content:{} ", userId, notification.getContent());
             } catch (IOException e) {
                 log.error("Failed to send SSE notification to userId: {}", userId, e);
                 // 전송 실패 시 Emitter 삭제

--- a/src/test/java/org/example/hugmeexp/domain/praise/service/PraiseServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/praise/service/PraiseServiceTest.java
@@ -1,5 +1,6 @@
 package org.example.hugmeexp.domain.praise.service;
 
+import org.example.hugmeexp.domain.notification.service.NotificationService;
 import org.example.hugmeexp.domain.praise.dto.*;
 import org.example.hugmeexp.domain.praise.entity.Praise;
 import org.example.hugmeexp.domain.praise.entity.PraiseComment;
@@ -57,6 +58,9 @@ public class PraiseServiceTest {
 
     @Mock
     private CommentService commentService;
+
+    @Mock
+    private NotificationService notificationService;
 
     @InjectMocks
     private PraiseService praiseService;


### PR DESCRIPTION
close #192 
Commit
- 알림 기능 구현
- 칭찬 받을 때 알림 기능

![스크린샷 2025-07-07 225344](https://github.com/user-attachments/assets/0ddb1447-8df7-4405-aaa9-a19d81455348)
![스크린샷 2025-07-07 225401](https://github.com/user-attachments/assets/778d1a9b-cf60-41fb-948e-54e62c8c3afe)

칭찬을 자신에게 보내는 것이 아닌 다른 사람에게 보내게 된다면 받는 사람의 알림에 바로 저장 되게 구현했습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 알림 목록 조회, 개별 알림 읽음 처리, 전체 알림 읽음 처리 API가 추가되었습니다.
  * 실시간 알림 수신을 위한 SSE(Server-Sent Events) 구독 기능이 도입되었습니다.
  * 칭찬, 다이어리 댓글/좋아요, 레벨업 등 다양한 이벤트 발생 시 실시간 알림이 전송됩니다.
  * 알림 유형별 카테고리 구분 및 알림 데이터 구조가 확장되었습니다.
  * SSE 연결 관리를 위한 전용 저장소와 서비스가 추가되었습니다.

* **버그 수정**
  * 해당 없음.

* **기타**
  * 알림 관련 예외 처리 및 접근 제어가 강화되었습니다.
  * SSE 연결 관리 및 알림 전송 안정성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->