### PR TITLE
feat: 미션 및 미션 태스크에 팁 필드 추가

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/mission/dto/request/MissionRequest.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/dto/request/MissionRequest.java
@@ -28,4 +28,6 @@ public class MissionRequest {
     private int order;
     @NotNull
     private int line;
+    @Length(max = 511, message = "미션 팁은 최대 511자까지 입력할 수 있습니다.")
+    private String tip;
 }

--- a/src/main/java/org/example/hugmeexp/domain/mission/dto/response/MissionResponse.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/dto/response/MissionResponse.java
@@ -29,4 +29,6 @@ public class MissionResponse {
     private int order;
 
     private int line;
+
+    private String tip;
 }

--- a/src/main/java/org/example/hugmeexp/domain/mission/entity/Mission.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/entity/Mission.java
@@ -41,4 +41,7 @@ public class Mission extends BaseEntity {
 
     @Column(name = "mission_line", nullable = false)
     private int line;
+
+    @Column(name = "tip", length = 511)
+    private String tip;
 }

--- a/src/main/java/org/example/hugmeexp/domain/mission/service/MissionServiceImpl.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/service/MissionServiceImpl.java
@@ -66,6 +66,7 @@ public class MissionServiceImpl implements MissionService {
                 .rewardExp(missionRequest.getRewardExp())
                 .order(missionRequest.getOrder())
                 .line(missionRequest.getLine())
+                .tip(missionRequest.getTip())
                 .build();
 
         Mission updatedMission = missionRepository.save(mission);

--- a/src/main/java/org/example/hugmeexp/domain/missionTask/dto/request/MissionTaskRequest.java
+++ b/src/main/java/org/example/hugmeexp/domain/missionTask/dto/request/MissionTaskRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 @Data
 @NoArgsConstructor
@@ -14,4 +15,6 @@ public class MissionTaskRequest {
     private String name;
     @Positive(message = "공수는 양수여야 합니다")
     private int score; // 공수
+    @Length(max = 511, message = "팁은 최대 511자까지 가능합니다")
+    private String tip;
 }

--- a/src/main/java/org/example/hugmeexp/domain/missionTask/dto/response/MissionTaskResponse.java
+++ b/src/main/java/org/example/hugmeexp/domain/missionTask/dto/response/MissionTaskResponse.java
@@ -12,4 +12,5 @@ public class MissionTaskResponse {
     private Long mission_id;
     private String name;
     private int score; // 공수
+    private String tip;
 }

--- a/src/main/java/org/example/hugmeexp/domain/missionTask/entity/MissionTask.java
+++ b/src/main/java/org/example/hugmeexp/domain/missionTask/entity/MissionTask.java
@@ -27,4 +27,8 @@ public class MissionTask extends BaseEntity {
     @Setter
     @Column(name = "score", nullable = false)
     private int score; // 공수
+
+    @Setter
+    @Column(name = "tip", length = 511)
+    private String tip;
 }

--- a/src/main/java/org/example/hugmeexp/domain/missionTask/service/MissionTaskServiceImpl.java
+++ b/src/main/java/org/example/hugmeexp/domain/missionTask/service/MissionTaskServiceImpl.java
@@ -88,6 +88,7 @@ public class MissionTaskServiceImpl implements MissionTaskService {
 
         existingMissionTask.setName(request.getName());
         existingMissionTask.setScore(request.getScore());
+        existingMissionTask.setTip(request.getTip());
     }
 
     @Transactional

--- a/src/test/java/org/example/hugmeexp/domain/mission/service/MissionServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/mission/service/MissionServiceTest.java
@@ -53,6 +53,7 @@ class MissionServiceTest {
             .rewardExp(50)
             .order(1)
             .missionGroupId(SAMPLE_ID)
+            .tip("미션 팁")
             .build();
 
 
@@ -167,6 +168,7 @@ class MissionServiceTest {
                 .rewardPoint(SAMPLE_REQUEST.getRewardPoint())
                 .rewardExp(SAMPLE_REQUEST.getRewardExp())
                 .order(SAMPLE_REQUEST.getOrder())
+                .tip(SAMPLE_REQUEST.getTip())
                 .build();
 
         MissionResponse expectedResponse = MissionResponse.builder().id(SAMPLE_ID).name("미션명").build();
@@ -183,6 +185,7 @@ class MissionServiceTest {
         verify(missionRepository).save(argThat(m -> {
             assertThat(m.getName()).isEqualTo("미션명");
             assertThat(m.getDescription()).isEqualTo("미션 설명");
+            assertThat(m.getTip()).isEqualTo(SAMPLE_REQUEST.getTip());
             return true;
         }));
     }


### PR DESCRIPTION
미션과 미션 태스크에 최대 511자까지 입력할 수 있는 팁 필드를 추가했습니다.

closes #197 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 미션 및 미션 태스크에 '팁' 입력란이 추가되었습니다. 최대 511자까지 입력할 수 있습니다.

* **버그 수정**
  * 미션 및 미션 태스크 수정 시 '팁' 정보가 정상적으로 반영됩니다.

* **테스트**
  * '팁' 필드가 포함된 미션 관련 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->