### PR TITLE
feat: 미션 및 유저 미션 그룹의 일대다 관계 설정

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/mission/entity/Mission.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/entity/Mission.java
@@ -4,7 +4,11 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.example.hugmeexp.domain.mission.enums.Difficulty;
 import org.example.hugmeexp.domain.missionGroup.entity.MissionGroup;
+import org.example.hugmeexp.domain.missionTask.entity.MissionTask;
 import org.example.hugmeexp.global.entity.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -44,4 +48,10 @@ public class Mission extends BaseEntity {
 
     @Column(name = "tip", length = 511)
     private String tip;
+
+    @OneToMany(mappedBy = "mission", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<UserMission> userMissions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "mission", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<MissionTask> missionTasks = new ArrayList<>();
 }

--- a/src/main/java/org/example/hugmeexp/domain/mission/entity/UserMission.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/entity/UserMission.java
@@ -7,6 +7,9 @@ import org.example.hugmeexp.domain.missionGroup.entity.UserMissionGroup;
 import org.example.hugmeexp.domain.user.entity.User;
 import org.example.hugmeexp.global.entity.BaseEntity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"user_id", "mission_id", "user_mission_group_id"})})
 @Getter
@@ -30,4 +33,16 @@ public class UserMission extends BaseEntity {
     @Setter
     @Enumerated(EnumType.STRING)
     private UserMissionState progress;
+
+    @OneToOne(mappedBy = "userMission", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Submission submissions;
+
+    @OneToMany(mappedBy = "userMission", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<MissionRewardExpLog> missionRewardExpLogs = new ArrayList<>();
+
+    @OneToMany(mappedBy = "userMission", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<MissionRewardPointLog> missionRewardPointLogs = new ArrayList<>();
+
+    @OneToMany(mappedBy = "userMission", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<UserMissionStateLog> userMissionStateLogs = new ArrayList<>();
 }

--- a/src/main/java/org/example/hugmeexp/domain/mission/entity/UserMission.java
+++ b/src/main/java/org/example/hugmeexp/domain/mission/entity/UserMission.java
@@ -35,7 +35,7 @@ public class UserMission extends BaseEntity {
     private UserMissionState progress;
 
     @OneToOne(mappedBy = "userMission", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    private Submission submissions;
+    private Submission submission;
 
     @OneToMany(mappedBy = "userMission", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<MissionRewardExpLog> missionRewardExpLogs = new ArrayList<>();

--- a/src/main/java/org/example/hugmeexp/domain/missionGroup/entity/MissionGroup.java
+++ b/src/main/java/org/example/hugmeexp/domain/missionGroup/entity/MissionGroup.java
@@ -2,6 +2,7 @@ package org.example.hugmeexp.domain.missionGroup.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.example.hugmeexp.domain.mission.entity.Mission;
 import org.example.hugmeexp.global.entity.BaseEntity;
 import org.example.hugmeexp.domain.user.entity.User;
 
@@ -23,6 +24,9 @@ public class MissionGroup extends BaseEntity {
     @Column(nullable = false, length = 127)
     private String name;
 
-    @OneToMany(mappedBy = "missionGroup", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "missionGroup", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<UserMissionGroup> userMissionGroups = new ArrayList<>();
+
+    @OneToMany(mappedBy = "missionGroup", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Mission> missions = new ArrayList<>();
 }

--- a/src/main/java/org/example/hugmeexp/domain/missionGroup/entity/UserMissionGroup.java
+++ b/src/main/java/org/example/hugmeexp/domain/missionGroup/entity/UserMissionGroup.java
@@ -15,10 +15,10 @@ public class UserMissionGroup extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mission_group_id", nullable = false)
     private MissionGroup missionGroup;
 }

--- a/src/main/java/org/example/hugmeexp/domain/user/dto/response/UserRankResponse.java
+++ b/src/main/java/org/example/hugmeexp/domain/user/dto/response/UserRankResponse.java
@@ -2,7 +2,9 @@ package org.example.hugmeexp.domain.user.dto.response;
 
 import lombok.Builder;
 import lombok.Data;
+import org.example.hugmeexp.domain.missionGroup.dto.response.MissionGroupResponse;
 import org.example.hugmeexp.domain.user.entity.User;
+import java.util.List;
 
 @Data
 @Builder(toBuilder = true)
@@ -15,6 +17,7 @@ public class UserRankResponse {
     private int level;
     private int exp;
     private int rank;
+    private List<MissionGroupResponse> missionGroups;
 
     public static UserRankResponse from(User user, int rank, int level) {
         return UserRankResponse.builder()
@@ -26,6 +29,10 @@ public class UserRankResponse {
                 .level(level)
                 .exp(user.getExp())
                 .rank(rank)
+                .missionGroups(user.getUserMissionGroupList().stream().map(userMissionGroup -> MissionGroupResponse.builder()
+                        .name(userMissionGroup.getMissionGroup().getName())
+                        .build())
+                .toList())
                 .build();
     }
 }

--- a/src/main/java/org/example/hugmeexp/domain/user/entity/User.java
+++ b/src/main/java/org/example/hugmeexp/domain/user/entity/User.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.hugmeexp.domain.attendance.entity.Attendance;
+import org.example.hugmeexp.domain.missionGroup.entity.UserMissionGroup;
 import org.example.hugmeexp.domain.user.enums.UserRole;
 import org.example.hugmeexp.domain.user.exception.InvalidValueException;
 import org.example.hugmeexp.global.entity.BaseEntity;
@@ -63,8 +64,11 @@ public class User extends BaseEntity {
     private String phoneNumber;
 
     // attendance와 양방향 연관관계 + cascade 설정으로 유저 삭제 시 출석 기록도 삭제
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Attendance> attendanceList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<UserMissionGroup> userMissionGroupList = new ArrayList<>();
 
     @Builder
     private User(String username, String password, String name, String phoneNumber) {

--- a/src/main/java/org/example/hugmeexp/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/user/repository/UserRepository.java
@@ -2,6 +2,7 @@ package org.example.hugmeexp.domain.user.repository;
 
 import org.example.hugmeexp.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -26,5 +27,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // phoneNumber를 바탕으로 User 리턴
     Optional<User> findByPhoneNumber(String phoneNumber);
 
+    @Query("SELECT u FROM User u JOIN FETCH u.userMissionGroupList umg JOIN FETCH umg.missionGroup ORDER BY u.exp DESC")
     List<User> findAllByOrderByExpDesc();
 }


### PR DESCRIPTION
미션과 유저 미션 그룹 간의 일대다 관계를 설정하고, 관련된 엔티티에 대한 cascade 옵션을 추가했습니다. 또한, Lazy loading을 적용하여 성능을 개선했습니다.

closes #213 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자 랭크 응답에 미션 그룹 정보가 추가되었습니다.

* **개선 사항**
  * 여러 엔티티 간 관계가 확장되어 미션, 미션 그룹, 사용자 미션 그룹, 미션 태스크, 보상 로그, 상태 로그 등 다양한 정보를 더 효율적으로 관리할 수 있게 되었습니다.
  * 주요 연관 관계의 조회 방식이 지연 로딩(LAZY)으로 변경되어 성능이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->