### PR TITLE
북마크 도메인 성능개선

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/org/example/hugmeexp/domain/bookmark/service/BookmarkService.java
@@ -9,10 +9,12 @@ import org.example.hugmeexp.domain.bookmark.exception.BookmarkUserNotFoundExcept
 import org.example.hugmeexp.domain.bookmark.repository.BookmarkRepository;
 import org.example.hugmeexp.domain.user.entity.User;
 import org.example.hugmeexp.domain.user.repository.UserRepository;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -24,6 +26,7 @@ public class BookmarkService {
 
     /** 전체 북마크 조회 */
     @Transactional(readOnly = true)
+    @Cacheable(value = "userBookmarks", key = "#username")
     public List<BookmarkResponse> getBookmarks(String username) {
         return bookmarkRepository
                 .findAllByUser_Username(username).stream()
@@ -33,6 +36,7 @@ public class BookmarkService {
 
     /** 북마크 추가 */
     @Transactional
+    @CacheEvict(value = "userBookmarks", key = "#username")
     public void createBookmark(String username, BookmarkRequest req) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(BookmarkUserNotFoundException::new);
@@ -48,6 +52,7 @@ public class BookmarkService {
 
     /** 북마크 수정 */
     @Transactional
+    @CacheEvict(value = "userBookmarks", key = "#username")
     public void updateBookmark(String username, Long id, BookmarkRequest req) {
         if (req.getTitle() == null || req.getTitle().trim().isEmpty()) {
             throw new IllegalArgumentException("북마크 제목은 필수입니다");}
@@ -62,6 +67,7 @@ public class BookmarkService {
 
     /** 북마크 삭제 */
     @Transactional
+    @CacheEvict(value = "userBookmarks", key = "#username")
     public void deleteBookmark(String username, Long id) {
         Bookmark b = bookmarkRepository
                 .findByIdAndUser_Username(id, username)


### PR DESCRIPTION
- redis의 @Cacheable / @CacheEvict 사용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **성능 개선**
  * 북마크 목록 조회 시 캐시를 적용하여 응답 속도가 향상되었습니다.
  * 북마크 추가, 수정, 삭제 시 캐시가 자동으로 갱신되어 최신 정보가 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->